### PR TITLE
Fix state file permission error

### DIFF
--- a/lib/silo/commands/type_avail.rb
+++ b/lib/silo/commands/type_avail.rb
@@ -38,7 +38,7 @@ module FlightSilo
           table = Table.new
           table.headers 'Name', 'Description', 'Prepared'
           Type.each do |t|
-            table.row Paint[t.name, :cyan], Paint[t.description, :green], t.prepared
+            table.row Paint[t.name, :cyan], Paint[t.description, :green], t.prepared?
           end
           table.emit
         end

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -80,7 +80,7 @@ module FlightSilo
     end
 
     def check_prepared
-      raise "Type '#{@type.name}' is not prepared" unless @type.prepared
+      raise "Type '#{@type.name}' is not prepared" unless @type.prepared?
     end
 
     attr_reader :name, :type, :global, :description, :is_public, :region

--- a/lib/silo/type.rb
+++ b/lib/silo/type.rb
@@ -55,19 +55,18 @@ module FlightSilo
       modify_state do |s|
         s.tap { |h| h[:prepared] = true }
       end
-
-      @prepared = true
     end
 
-    attr_reader :name, :description, :dir, :prepared
+    def prepared?
+      !!state[:prepared]
+    end
+
+    attr_reader :name, :description, :dir
 
     def initialize(md, dir)
       @name = md[:name]
       @description = md[:description]
       @dir = dir
-
-      FileUtils.touch(state_file)
-      @prepared = !!state[:prepared]
     end
   end
 end


### PR DESCRIPTION
When trying to do anything involving types as a regular user, a permissions error is raised as `Type#initialize` is trying to `touch` the state file at `/opt/flight/opt/silo/etc/types/__/`. A permissions error is raised because the user doesn't have write permissions for this directory. This PR removes the `touch` call, and replaces the `@prepared` attribute on `Type` with `Type#prepared?`.