### PR TITLE
Make commands/logic less type-specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ tmp
 vendor
 var
 etc/config.yml
-etc/types/aws/cli
-etc/types/aws/state.yaml
+etc/types/*/cli
+etc/types/*/state.yaml

--- a/etc/types/aws/actions/dir_exists.sh
+++ b/etc/types/aws/actions/dir_exists.sh
@@ -1,10 +1,10 @@
 bucket=$1
-key=${2:1}
-export AWS_DEFAULT_REGION=$3
-export AWS_ACCESS_KEY_ID=$4
-export AWS_SECRET_ACCESS_KEY=$5
-sign_request=$6
-not_exist=$($flight_SILO_types/aws/cli/bin/aws s3api head-object --bucket "$bucket" --key "$key" --region "$region" $6 >/dev/null 2>&1; echo $?)
+test $2 = true && sign_request=--no-sign-request || sign_request=""
+key=${3:1}
+export AWS_DEFAULT_REGION=$4
+export AWS_ACCESS_KEY_ID=$5
+export AWS_SECRET_ACCESS_KEY=$6
+not_exist=$($flight_SILO_types/aws/cli/bin/aws s3api head-object --bucket "$bucket" --key "$key" $sign_request --output json >/dev/null 2>&1; echo $?)
 if [ $not_exist == 254 ]; then
   echo "no"
 else

--- a/etc/types/aws/actions/dir_exists.sh
+++ b/etc/types/aws/actions/dir_exists.sh
@@ -1,7 +1,10 @@
 bucket=$1
 key=${2:1}
-region=$3
-not_exist=$($flight_SILO_types/aws/cli/bin/aws s3api head-object --bucket "$bucket" --key "$key" --no-sign-request --region "$region">/dev/null 2>&1; echo $?)
+export AWS_DEFAULT_REGION=$3
+export AWS_ACCESS_KEY_ID=$4
+export AWS_SECRET_ACCESS_KEY=$5
+sign_request=$6
+not_exist=$($flight_SILO_types/aws/cli/bin/aws s3api head-object --bucket "$bucket" --key "$key" --region "$region" $6 >/dev/null 2>&1; echo $?)
 if [ $not_exist == 254 ]; then
   echo "no"
 else

--- a/etc/types/aws/actions/file_exists.sh
+++ b/etc/types/aws/actions/file_exists.sh
@@ -1,7 +1,10 @@
 bucket=$1
-key=${2:1}
-region=$3
-not_exist=$($flight_SILO_types/aws/cli/bin/aws s3api head-object --bucket "$bucket" --key "$key" --no-sign-request --region "$region" >/dev/null 2>&1; echo $?)
+test $2 = true && sign_request=--no-sign-request || sign_request=""
+key=${3:1}
+export AWS_DEFAULT_REGION=$4
+export AWS_ACCESS_KEY_ID=$5
+export AWS_SECRET_ACCESS_KEY=$6
+not_exist=$($flight_SILO_types/aws/cli/bin/aws s3api head-object --bucket "$bucket" --key "$key" $sign_request --output json >/dev/null 2>&1; echo $?)
 if [ $not_exist == 254 ]; then
   echo "no"
 else

--- a/etc/types/aws/actions/list.sh
+++ b/etc/types/aws/actions/list.sh
@@ -4,4 +4,14 @@ prefix=${3:1}
 export AWS_DEFAULT_REGION=$4
 export AWS_ACCESS_KEY_ID=$5
 export AWS_SECRET_ACCESS_KEY=$6
-$flight_SILO_types/aws/cli/bin/aws s3api list-objects-v2 --bucket "$bucket" --prefix "$prefix" --delimiter / --output json $sign_request
+files=$($flight_SILO_types/aws/cli/bin/aws s3api list-objects-v2 --bucket "$bucket" --prefix "$prefix" --delimiter / --output yaml --query Contents[:].Key $sign_request)
+dirs=$($flight_SILO_types/aws/cli/bin/aws s3api list-objects-v2 --bucket "$bucket" --prefix "$prefix" --delimiter / --output yaml --query CommonPrefixes[:].Prefix $sign_request)
+echo "---"
+if [ "$files" != null ]; then
+  echo "files:"
+  echo -e "$files" | tail -n +2
+fi
+if [ "$dirs" != null ]; then
+  echo "dirs:"
+  echo -e "$dirs"
+fi

--- a/etc/types/aws/actions/list.sh
+++ b/etc/types/aws/actions/list.sh
@@ -1,7 +1,7 @@
 bucket=$1
-prefix=${2:1}
-export AWS_DEFAULT_REGION=$3
-export AWS_ACCESS_KEY_ID=$4
-export AWS_SECRET_ACCESS_KEY=$5
-sign_request=$6
+test $2 = true && sign_request=--no-sign-request || sign_request=""
+prefix=${3:1}
+export AWS_DEFAULT_REGION=$4
+export AWS_ACCESS_KEY_ID=$5
+export AWS_SECRET_ACCESS_KEY=$6
 $flight_SILO_types/aws/cli/bin/aws s3api list-objects-v2 --bucket "$bucket" --prefix "$prefix" --delimiter / --output json $sign_request

--- a/etc/types/aws/actions/pull.sh
+++ b/etc/types/aws/actions/pull.sh
@@ -1,7 +1,8 @@
-object_uri="s3://$1$2"
-destination=$3
-export AWS_DEFAULT_REGION=$4
-export AWS_ACCESS_KEY_ID=$5
-export AWS_SECRET_ACCESS_KEY=$6
-recursive=$7
-$flight_SILO_types/aws/cli/bin/aws s3 cp "$object_uri" "$destination" $recursive
+object_uri="s3://$1$3"
+test $2 = true && sign_request=--no-sign-request || sign_request=""
+destination=$4
+test $5 = true && recursive=--recursive || recursive=""
+export AWS_DEFAULT_REGION=$6
+export AWS_ACCESS_KEY_ID=$7
+export AWS_SECRET_ACCESS_KEY=$8
+$flight_SILO_types/aws/cli/bin/aws s3 cp "$object_uri" "$destination" $sign_request $recursive

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -56,19 +56,9 @@ module FlightSilo
 
         sign_request = silo.is_public ? " --no-sign-request" : ""
 
-        ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-        data = JSON.load(`/bin/bash #{Config.root}/etc/types/#{silo.type.name}/actions/list.sh #{silo_name} #{dir} #{silo.region} #{silo.access_key} #{silo.secret_key} #{sign_request}`)
-
-        # Type-specific
-        if data == nil
-          raise "Directory /#{dir} is empty, or doesn't exist"
-        end
-        if data["Contents"]
-          files = data["Contents"]&.map{ |obj| File.basename(obj["Key"][6..-1]) }[1..-1]
-        end
-        if data["CommonPrefixes"]
-          dirs = data["CommonPrefixes"]&.map{ |obj| File.basename(obj["Prefix"][6..-1]) }
-        end
+        raise "Remote directory '#{dir.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(dir)
+        
+        dirs, files = silo.list(dir)
 
         dirs&.each do |dir|
           puts Paint[bold(dir), :blue]

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -61,7 +61,7 @@ module FlightSilo
         dirs&.each do |dir|
           puts Paint[" " + bold(dir), :blue]
         end
-        puts files.map{ |f| " " + f }
+        puts files&.map { |f| " " + f }
       end
 
       def bold(string)

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -52,7 +52,7 @@ module FlightSilo
         silo = Silo[silo_name]
 
         dir = File.join("/files/", dir.to_s.chomp("/"), "/")
-        raise "Remote directory '#{dir.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(dir, silo.region)
+        raise "Remote directory '#{dir.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(dir)
 
         sign_request = silo.is_public ? " --no-sign-request" : ""
 

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -52,12 +52,9 @@ module FlightSilo
         silo = Silo[silo_name]
 
         dir = File.join("/files/", dir.to_s.chomp("/"), "/")
+        silo = Silo[silo_name]
+
         raise "Remote directory '#{dir.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(dir)
-
-        sign_request = silo.is_public ? " --no-sign-request" : ""
-        raise "Remote directory '#{dir.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(dir, silo.region, silo.access_key, silo.secret_key, sign_request)
-
-        raise "Remote directory '#{dir.delete_prefix("/files")}' not found" unless silo.dir_exists?(dir)
         
         dirs, files = silo.list(dir)
 

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -55,6 +55,7 @@ module FlightSilo
         raise "Remote directory '#{dir.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(dir)
 
         sign_request = silo.is_public ? " --no-sign-request" : ""
+        raise "Remote directory '#{dir.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(dir, silo.region, silo.access_key, silo.secret_key, sign_request)
 
         raise "Remote directory '#{dir.delete_prefix("/files")}' not found" unless silo.dir_exists?(dir)
         

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -61,9 +61,9 @@ module FlightSilo
         dirs, files = silo.list(dir)
 
         dirs&.each do |dir|
-          puts Paint[bold(dir), :blue]
+          puts Paint[" " + bold(dir), :blue]
         end
-        puts files
+        puts files.map{ |f| " " + f }
       end
 
       def bold(string)

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -54,8 +54,7 @@ module FlightSilo
         dir = File.join("/files/", dir.to_s.chomp("/"), "/")
         silo = Silo[silo_name]
 
-        raise "Remote directory '#{dir.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(dir)
-        
+        raise NoSuchDirectoryError, "Remote directory '#{dir.delete_prefix("/files")}' not found" unless silo.dir_exists?(dir)
         dirs, files = silo.list(dir)
 
         dirs&.each do |dir|

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -56,7 +56,7 @@ module FlightSilo
 
         sign_request = silo.is_public ? " --no-sign-request" : ""
 
-        raise "Remote directory '#{dir.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(dir)
+        raise "Remote directory '#{dir.delete_prefix("/files")}' not found" unless silo.dir_exists?(dir)
         
         dirs, files = silo.list(dir)
 

--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -56,13 +56,13 @@ module FlightSilo
         silo = Silo[silo_name]
         if @options.recursive
           source = File.join("/files/", source.to_s.chomp("/"), "/")
-          raise "Remote directory '#{source.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(source)
+          raise "Remote directory '#{source.delete_prefix("/files")}' not found" unless silo.dir_exists?(source)
         else
           source = File.join("/files/", source.to_s.chomp("/"))
-          raise "Remote file '#{source.delete_prefix("/files")}' does not exist (use --recursive to pull directories)" unless silo.file_exists?(source)
+          raise "Remote file '#{source.delete_prefix("/files")}' not found (use --recursive to pull directories)" unless silo.file_exists?(source)
         end
         parent = File.expand_path("..", dest)
-        raise "The parent directory '#{parent}' does not exist" unless File.directory?(parent)
+        raise "Parent directory '#{parent}' not found" unless File.directory?(parent)
 
         puts "Pulling '#{silo.name}:#{source.delete_prefix("/files")}' into '#{dest}'..."
 

--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -56,13 +56,13 @@ module FlightSilo
         silo = Silo[silo_name]
         if @options.recursive
           source = File.join("/files/", source.to_s.chomp("/"), "/")
-          raise "Remote directory '#{source.delete_prefix("/files")}' not found" unless silo.dir_exists?(source)
+          raise NoSuchDirectoryError, "Remote directory '#{source.delete_prefix("/files")}' not found" unless silo.dir_exists?(source)
         else
           source = File.join("/files/", source.to_s.chomp("/"))
-          raise "Remote file '#{source.delete_prefix("/files")}' not found (use --recursive to pull directories)" unless silo.file_exists?(source)
+          raise NoSuchFileError, "Remote file '#{source.delete_prefix("/files")}' not found (use --recursive to pull directories)" unless silo.file_exists?(source)
         end
         parent = File.expand_path("..", dest)
-        raise "Parent directory '#{parent}' not found" unless File.directory?(parent)
+        raise NoSuchDirectoryError, "Parent directory '#{parent}' not found" unless File.directory?(parent)
 
         puts "Pulling '#{silo.name}:#{source.delete_prefix("/files")}' into '#{dest}'..."
 

--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -56,22 +56,20 @@ module FlightSilo
         silo = Silo[silo_name]
         if @options.recursive
           source = File.join("/files/", source.to_s.chomp("/"), "/")
-          raise "Remote directory '#{source.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(source, silo.region)
+          raise "Remote directory '#{source.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(source)
         else
           source = File.join("/files/", source.to_s.chomp("/"))
-          raise "Remote file '#{source.delete_prefix("/files")}' does not exist (use --recursive to pull directories)" unless silo.file_exists?(source, silo.region)
+          raise "Remote file '#{source.delete_prefix("/files")}' does not exist (use --recursive to pull directories)" unless silo.file_exists?(source)
         end
         parent = File.expand_path("..", dest)
         raise "The parent directory '#{parent}' does not exist" unless File.directory?(parent)
-        
-        puts "Pulling '#{source.delete_prefix("/files")}' into '#{dest}'..."
+
+        puts "Pulling '#{silo.name}:#{source.delete_prefix("/files")}' into '#{dest}'..."
 
         `mkdir #{dest} >/dev/null 2>&1`
         dest = dest + "/" + File.basename(source) unless keep_parent
-        recursive = @options.recursive ? " --recursive" : ""
 
-        ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-        response = `/bin/bash #{Config.root}/etc/types/#{Silo[silo_name].type.name}/actions/pull.sh #{silo_name} #{source} #{dest} #{Silo[silo_name].region}#{recursive}`
+        silo.pull(source, dest, @options.recursive)
         puts "File(s) downloaded to #{dest}"
       end
     end

--- a/lib/silo/errors.rb
+++ b/lib/silo/errors.rb
@@ -29,4 +29,6 @@ module FlightSilo
   UnknownSiloTypeError = Class.new(RuntimeError)
   SiloExistsError = Class.new(RuntimeError)
   NoSuchSiloError = Class.new(RuntimeError)
+  NoSuchDirectoyError = Class.new(RuntimeError)
+  NoSuchFileError = Class.new(RuntimeError)
 end

--- a/lib/silo/errors.rb
+++ b/lib/silo/errors.rb
@@ -29,6 +29,6 @@ module FlightSilo
   UnknownSiloTypeError = Class.new(RuntimeError)
   SiloExistsError = Class.new(RuntimeError)
   NoSuchSiloError = Class.new(RuntimeError)
-  NoSuchDirectoyError = Class.new(RuntimeError)
+  NoSuchDirectoryError = Class.new(RuntimeError)
   NoSuchFileError = Class.new(RuntimeError)
 end

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -90,8 +90,13 @@ module FlightSilo
       `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/dir_exists.sh #{@name} #{@is_public} #{path}#{credentials}`.chomp=="yes"
     end
 
-    def file_exists?(path, *args)
-      extra_args = " " + args.join(" ")
+    def file_exists?(path)
+      credentials = " " + @creds.values.join(" ")
+      check_prepared
+      ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
+      `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/file_exists.sh #{@name} #{@is_public} #{path}#{credentials}`.chomp=="yes"
+    end
+
       check_prepared
       ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
       `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/file_exists.sh #{@name} #{path}#{extra_args}`.chomp=="yes"

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -117,9 +117,11 @@ module FlightSilo
       return [dirs, files]
     end
 
+    def pull(source, dest, recursive)
+      credentials = " " + @creds.values.join(" ")
       check_prepared
       ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-      `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/file_exists.sh #{@name} #{path}#{extra_args}`.chomp=="yes"
+      response = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/pull.sh #{@name} #{@is_public} #{source} #{dest} #{recursive}#{credentials}`
     end
 
     def check_prepared

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -83,12 +83,11 @@ module FlightSilo
       end
     end
 
-    # Extra args are for type-specific required details, e.g. AWS region
-    def dir_exists?(path, *args)
-      extra_args = " " + args.join(" ")
+    def dir_exists?(path)
+      credentials = " " + @creds.values.join(" ")
       check_prepared
       ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-      `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/dir_exists.sh #{@name} #{path}#{extra_args}`.chomp=="yes"
+      `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/dir_exists.sh #{@name} #{@is_public} #{path}#{credentials}`.chomp=="yes"
     end
 
     def file_exists?(path, *args)
@@ -102,17 +101,15 @@ module FlightSilo
       raise "Type '#{@type.name}' is not prepared" unless @type.prepared?
     end
 
-    attr_reader :name, :type, :global, :description, :is_public, :region, :access_key, :secret_key
+    attr_reader :name, :type, :global, :description, :is_public, :creds
 
     def initialize(global: false, md: {})
-      @name = md["name"]
-      @type = Type[md["type"]]
-      @description = md["description"]
-      @is_public = md["is_public"]
-
-      @region = md["region"] || "none"          #
-      @access_key = md["access_key"] || "none"  # --- AWS specific
-      @secret_key = md["secret_key"] || "none" #
+      @name = md.delete("name")
+      @type = Type[md.delete("type")]
+      @description = md.delete("description")
+      @is_public = md.delete("is_public")
+      
+      @creds = md # Credentials are all unused metadata values
     end
   end
 end

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -84,44 +84,35 @@ module FlightSilo
     end
 
     def dir_exists?(path)
-      credentials = " " + @creds.values.join(" ")
+      credentials = @creds.values.join(" ")
       check_prepared
       ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-      `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/dir_exists.sh #{@name} #{@is_public} #{path}#{credentials}`.chomp=="yes"
+      `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/dir_exists.sh #{@name} #{@is_public} #{path} #{credentials}`.chomp=="yes"
     end
 
     def file_exists?(path)
-      credentials = " " + @creds.values.join(" ")
+      credentials = @creds.values.join(" ")
       check_prepared
       ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-      `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/file_exists.sh #{@name} #{@is_public} #{path}#{credentials}`.chomp=="yes"
+      `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/file_exists.sh #{@name} #{@is_public} #{path} #{credentials}`.chomp=="yes"
     end
 
     def list(path)
-      credentials = " " + @creds.values.join(" ")
+      credentials = @creds.values.join(" ")
       check_prepared
       ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-      response = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/list.sh #{@name} #{@is_public} #{path}#{credentials}`
-      
-      # Type-specific
-      data = JSON.load(response)
-      if data == nil
-        raise "Directory /#{path} is empty"
-      end
-      if data["Contents"]
-        files = data["Contents"]&.map{ |obj| File.basename(obj["Key"][6..-1]) }[1..-1]
-      end
-      if data["CommonPrefixes"]
-        dirs = data["CommonPrefixes"]&.map{ |obj| File.basename(obj["Prefix"][6..-1]) }
-      end
-      return [dirs, files]
-    end
+      response = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/list.sh #{@name} #{@is_public} #{path} #{credentials}`
+      data = YAML.load(response)
+
+      return [data["dirs"]&.map { |d| File.basename(d) },
+              data["files"]&.map { |f| File.basename(f) }]
+    end 
 
     def pull(source, dest, recursive)
-      credentials = " " + @creds.values.join(" ")
+      credentials = @creds.values.join(" ")
       check_prepared
       ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-      response = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/pull.sh #{@name} #{@is_public} #{source} #{dest} #{recursive}#{credentials}`
+      response = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/pull.sh #{@name} #{@is_public} #{source} #{dest} #{recursive} #{credentials}`
     end
 
     def check_prepared

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -106,7 +106,7 @@ module FlightSilo
       # Type-specific
       data = JSON.load(response)
       if data == nil
-        raise "Directory /#{path} not found"
+        raise "Directory /#{path} is empty"
       end
       if data["Contents"]
         files = data["Contents"]&.map{ |obj| File.basename(obj["Key"][6..-1]) }[1..-1]


### PR DESCRIPTION
This PR aims to eliminate the reliance on AWS that some aspects of Silo were previously built around. Silo has been made considerably more modular, such that adding new provider types should be almost entirely self-contained. The `list` and `pull` commands have been restructured and much of their logic has been moved into the `Silo` class. Those commands, as well as the existing `dir_exists?` and `file_exists?` commands, now follow a more specific general ordering for their arguments:

- Silo name
- Whether the silo is public (i.e. whether to check credentials)
- Required arguments for the command itself (e.g. file paths)
- 0 or more credentials, always given in the same order, this being the order that they were collected by `repo add`. For AWS this is `region`, `access key id`, `secret key`. Any element in the silo's metadata which is not an attribute of all silos is considered a credential.

One aspect which is still type-specific is listing directory contents - AWS returns a JSON file representing this data, which is processed in `Silo#list`. Depending on how future providers output data from a generic `ls` command I expect we'll come to a conclusion on how best to yield data from `list.sh` back to ruby, although for now this method seems as good as any.