### PR TITLE
Default silo

### DIFF
--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -56,6 +56,12 @@ module FlightSilo
       end
     end
 
+    command "set-default" do |c|
+      cli_syntax(c, '[SILO]')
+      c.description = "Set or view the default silo"
+      c.action Commands, :set_default
+    end
+
     command :create do |c|
       cli_syntax(c, 'TYPE')
       c.description = "Create a new storage silo"

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -36,18 +36,22 @@ module FlightSilo
         # ARGS:
         # [silo:dir]
 
-        if !args[0]
-          silo_name = Config.default_silo
-          dir = "/"
-        elsif args[0].match(/^[^:]*:[^:]*$/)
-          silo_name, dir = args[0].split(":")
-        else
-          silo_name = Config.default_silo
-          dir = args[0]
-        end
+        silo_name, dir = 
+          if args.empty?
+            [Silo.default, '/']
+          elsif args[0].match(/^[^:]*:[^:]*$/)
+            str = args[0].split(":")
+            repo = str[0].empty? ? Silo.default : str[0]
+            dir = str[1]
+            
+            [repo, dir]
+          else
+            [Silo.default, args[0]]
+          end
+
+        silo = Silo[silo_name]
 
         dir = File.join("/files/", dir.to_s.chomp("/"), "/")
-        silo = Silo[silo_name]
         raise "Remote directory '#{dir.delete_prefix("/files")}' does not exist" unless silo.dir_exists?(dir, silo.region)
 
         sign_request = silo.is_public ? " --no-sign-request" : ""

--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -41,7 +41,7 @@ module FlightSilo
         if args[0].match(/^[^:]*:[^:]*$/)
           silo_name, source = args[0].split(":")
         else
-          silo_name = Config.default_silo
+          silo_name = Silo.default
           source = args[0]
         end
 

--- a/lib/silo/commands/set_default.rb
+++ b/lib/silo/commands/set_default.rb
@@ -24,38 +24,21 @@
 # For more information on Flight Silo, please visit:
 # https://github.com/openflighthpc/flight-silo
 #==============================================================================
-require_relative 'commands/type_avail'
-require_relative 'commands/type_prepare'
-require_relative 'commands/create'
-require_relative 'commands/repo_add'
-require_relative 'commands/repo_list'
-require_relative 'commands/file_list'
-require_relative 'commands/file_pull'
-require_relative 'commands/set_default'
+require_relative '../command'
+require_relative '../silo'
 
 module FlightSilo
   module Commands
-    class << self
-      def method_missing(s, *a, &b)
-        if clazz = to_class(s)
-          clazz.new(*a).run!
+    class SetDefault < Command
+      def run
+        if args.empty?
+          # Print current default
+          puts Silo.default
         else
-          raise 'command not defined'
+          # Set new default
+          Silo.set_default(args.first)
+          puts "Default silo set to: #{args.first}"
         end
-      end
-
-      def respond_to_missing?(s)
-        !!to_class(s)
-      end
-
-      private
-      def to_class(s)
-        s.to_s.split('-').reduce(self) do |clazz, p|
-          p.gsub!(/_(.)/) {|a| a[1].upcase}
-          clazz.const_get(p[0].upcase + p[1..-1])
-        end
-      rescue NameError
-        nil
       end
     end
   end

--- a/lib/silo/config.rb
+++ b/lib/silo/config.rb
@@ -56,7 +56,7 @@ module FlightSilo
       def user_data
         @user_data ||= TTY::Config.new.tap do |cfg|
           xdg_config.all.map do |p|
-            File.join(p, _DIR_SUFFIX)
+            File.join(p, SILO_DIR_SUFFIX)
           end.each(&cfg.method(:append_path))
           begin
             cfg.read
@@ -83,10 +83,6 @@ module FlightSilo
 
       def root
         @root ||= File.expand_path(File.join(__dir__, '..', '..'))
-      end
-
-      def default_silo
-        @default_silo ||= data.fetch(:default_silo)
       end
 
       def type_paths

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -36,6 +36,10 @@ module FlightSilo
         !!all.find { |s| s.name == name }
       end
 
+      def default
+        Config.user_data.fetch(:default_silo)
+      end
+
       private
 
       def fetch(key)

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -31,7 +31,7 @@ module FlightSilo
 
         silo = type.create(name: name, global: global)
 
-        set_default(silo) if all.count == 1
+        set_default(silo) if default.nil?
       end
 
       def exists?(name)

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -30,6 +30,8 @@ module FlightSilo
         end
 
         silo = type.create(name: name, global: global)
+
+        set_default(silo) if all.count == 1
       end
 
       def exists?(name)

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -39,6 +39,7 @@ module FlightSilo
       end
 
       def default
+        raise "No default silo set!"
         Config.user_data.fetch(:default_silo)
       end
 

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -40,6 +40,18 @@ module FlightSilo
         Config.user_data.fetch(:default_silo)
       end
 
+      def remove_default
+        Config.user_data.delete(:default_silo)
+        Config.save_user_data
+      end
+
+      def set_default(silo_name)
+        self[silo_name].tap do |silo|
+          Config.user_data.set(:default_silo, value: silo.name)
+          Config.save_user_data
+        end
+      end
+
       private
 
       def fetch(key)


### PR DESCRIPTION
This PR adds functionality for setting a default silo.

The `set-default` command will set the default to the given argument, or print the current default when no argument is given.

The default silo data is now accessible from the `Silo` class instead of the `Config` class.