### PR TITLE
Handle errors when adding repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@
 source 'https://rubygems.org'
 
 gem 'commander-openflighthpc', '~> 2.2.0'
+gem 'open3'
 gem 'tty-prompt'
 gem 'tty-config'
 gem 'tty-table'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
       slop (~> 4.8)
     highline (2.1.0)
     json (2.6.3)
+    open3 (0.1.2)
     paint (2.1.1)
     parallel (1.22.1)
     parser (3.2.1.0)
@@ -68,6 +69,7 @@ PLATFORMS
 
 DEPENDENCIES
   commander-openflighthpc (~> 2.2.0)
+  open3
   rubocop
   tty-config
   tty-prompt

--- a/lib/silo/commands/repo_add.rb
+++ b/lib/silo/commands/repo_add.rb
@@ -75,7 +75,7 @@ module FlightSilo
         puts "Silo added"
       end
 
-     def prompt
+      def prompt
         @prompt ||= TTY::Prompt.new(help_color: :yellow)
       end
     end

--- a/lib/silo/commands/repo_add.rb
+++ b/lib/silo/commands/repo_add.rb
@@ -27,7 +27,9 @@
 require_relative '../command'
 require_relative '../silo'
 require_relative '../type'
+
 require 'yaml'
+require 'open3'
 require 'tty-prompt'
 
 module FlightSilo
@@ -35,9 +37,9 @@ module FlightSilo
     class RepoAdd < Command
       def run
         answers = prompt.collect do
-          type_name = key("type").ask("Provider type name:")
-          type = Type[type_name]
-          type.questions.each do |question|
+          types = Type.all.map { |t| [t.description, t.name] }.to_h
+          type = key("type").select("Provider type:", types)
+          Type[type].questions.each do |question|
             key(question[:id]).ask(question[:text]) do |q|
               q.required question[:validation][:required]
               if question[:validation].to_h.key?(:format)
@@ -48,14 +50,22 @@ module FlightSilo
           end
         end
         
-        puts answers.inspect
-
-        type = Type[answers["type"]]
+        type_name = answers["type"]
         puts "Obtaining silo details for '#{answers["name"]}'..."
 
-        type_dir = "#{Config.root}/etc/types/#{type.name}"
+        type_dir = "#{Config.root}/etc/types/#{type_name}"
         ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-        `/bin/bash #{type_dir}/actions/pull.sh #{answers["name"]} /cloud_metadata.yaml #{type_dir}/cloud_metadata.yaml #{answers["region"]} #{answers["access_key"]} #{answers["secret_key"]}`
+
+        stdout_str, stderr_str, status = Open3.capture3(
+          "/bin/bash #{type_dir}/actions/pull.sh #{answers["name"]} /cloud_metadata.yaml #{type_dir}/cloud_metadata.yaml #{answers["region"]} #{answers["access_key"]} #{answers["secret_key"]}"
+        )
+
+        unless status.success?
+          raise <<~OUT
+          Error validating credentials:
+          #{stderr_str.chomp}
+          OUT
+        end
 
         cloud_md = YAML.load_file("#{type_dir}/cloud_metadata.yaml")
         `rm "#{type_dir}/cloud_metadata.yaml"`
@@ -65,7 +75,7 @@ module FlightSilo
         puts "Silo added"
       end
 
-      def prompt
+     def prompt
         @prompt ||= TTY::Prompt.new(help_color: :yellow)
       end
     end


### PR DESCRIPTION
This PR adds some extra handling to the `repo add` command to halt the process if there was an error interacting with the cloud provider. It also changes the `Choose a provider` interface to be a select menu with options for each of the existing providers.