### PR TITLE
Move to using silo IDs

### DIFF
--- a/etc/public_silos/openflight.yaml
+++ b/etc/public_silos/openflight.yaml
@@ -3,4 +3,5 @@ name: "openflight"
 description: "Openflight software and resources"
 type: "aws"
 is_public: true
+id: "openflight"
 AWS_DEFAULT_REGION: "eu-west-2"

--- a/etc/types/aws/actions/get_silo.sh
+++ b/etc/types/aws/actions/get_silo.sh
@@ -1,12 +1,6 @@
+<<<<<<< HEAD
 #!/bin/bash
 data=$($SILO_TYPE_DIR/cli/bin/aws s3api list-buckets --output json)
-buckets=($(echo $data | 
-  sed -e 's/[{}]/''/g' | 
-    awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' |
-      sed -n -e 's/^.*Name": //p' |
-        grep flight-silo- |
-          cut -d'"' -f2))
-echo $buckets
 
 for bucket in ${buckets[@]}; do
   can_access=$($SILO_TYPE_DIR/cli/bin/aws s3api head-bucket --bucket $bucket >/dev/null 2>&1; echo $?)

--- a/etc/types/aws/actions/get_silo.sh
+++ b/etc/types/aws/actions/get_silo.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+data=$($SILO_TYPE_DIR/cli/bin/aws s3api list-buckets --output json)
+buckets=($(echo $data | 
+  sed -e 's/[{}]/''/g' | 
+    awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' |
+      sed -n -e 's/^.*Name": //p' |
+        grep flight-silo- |
+          cut -d'"' -f2))
+echo $buckets
+
+for bucket in ${buckets[@]}; do
+  can_access=$($SILO_TYPE_DIR/cli/bin/aws s3api head-bucket --bucket $bucket >/dev/null 2>&1; echo $?)
+  if [ $can_access == 0 ]; then
+    aws s3 cp s3://$bucket/cloud_metadata.yaml ./current_metadata.yaml >/dev/null
+    name=$(cat ./current_metadata.yaml | grep name: | awk '{print $2}' | cut -d'"' -f2)
+    rm ./current_metadata.yaml
+    if [ $name == $SILO_NAME ]; then
+      echo $bucket
+      exit 0
+    fi
+  fi
+done

--- a/etc/types/aws/actions/get_silo.sh
+++ b/etc/types/aws/actions/get_silo.sh
@@ -1,6 +1,11 @@
-<<<<<<< HEAD
 #!/bin/bash
 data=$($SILO_TYPE_DIR/cli/bin/aws s3api list-buckets --output json)
+buckets=($(echo $data |
+  sed -e 's/[{}]/''/g' |
+    awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' |
+      sed -n -e 's/^.*Name": //p' |
+        grep flight-silo- |
+          cut -d'"' -f2))
 
 for bucket in ${buckets[@]}; do
   can_access=$($SILO_TYPE_DIR/cli/bin/aws s3api head-bucket --bucket $bucket >/dev/null 2>&1; echo $?)

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -51,9 +51,6 @@ module FlightSilo
 
         silo = Silo[silo_name]
 
-        dir = File.join("files/", dir.to_s.chomp("/"), "/")
-        silo = Silo[silo_name]
-
         raise NoSuchDirectoryError, "Remote directory '#{dir.delete_prefix("/files")}' not found" unless silo.dir_exists?(dir)
         dirs, files = silo.list(dir)
 

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -53,7 +53,6 @@ module FlightSilo
 
         dir = File.join("files/", dir.to_s.chomp("/"), "/")
         silo = Silo[silo_name]
-
         raise NoSuchDirectoryError, "Remote directory '#{dir.delete_prefix("/files")}' not found" unless silo.dir_exists?(dir)
         dirs, files = silo.list(dir)
 

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -53,6 +53,7 @@ module FlightSilo
 
         dir = File.join("files/", dir.to_s.chomp("/"), "/")
         silo = Silo[silo_name]
+
         raise NoSuchDirectoryError, "Remote directory '#{dir.delete_prefix("/files")}' not found" unless silo.dir_exists?(dir)
         dirs, files = silo.list(dir)
 

--- a/lib/silo/commands/repo_add.rb
+++ b/lib/silo/commands/repo_add.rb
@@ -45,29 +45,10 @@ module FlightSilo
         metadata = ask_questions(questions[:metadata])
         credentials = ask_questions(questions[:credentials])
 
-        puts "Obtaining silo details for '#{type_name}'..."
+        answers = metadata.merge(credentials)
+        answers['type'] = type_name
 
-        # TODO: Might be worth removing `name` from questions, as they'll all require a name
-        md = {
-          'name' => metadata.delete("name"),
-          'type' => type_name,
-          'description' => '',
-          'is_public' => false
-        }.merge(credentials).merge(metadata)
-
-        new_silo = Silo.new(md: md.dup)
-
-        target = File.join(type.dir, 'cloud_metadata.yaml')
-        new_silo.pull('cloud_metadata.yaml', target, false)
-
-        # TODO: A lot of this logic ought to belong to the Silo class
-        cloud_md = YAML.load_file(target)
-        `rm #{target}`
-        `mkdir -p #{Config.user_silos_path}`
-
-        silo_path = File.join(Config.user_silos_path, new_silo.name) + ".yaml"
-        File.open(silo_path, "w") { |file| file.write(md.merge(cloud_md).to_yaml) }
-
+        Silo.add(answers)
         puts "Silo added"
       end
 

--- a/lib/silo/commands/repo_list.rb
+++ b/lib/silo/commands/repo_list.rb
@@ -36,12 +36,13 @@ module FlightSilo
           puts "No silos found."
         else
           table = Table.new
-          table.headers 'Name', 'Description', 'Platform', 'Public?'
+          table.headers 'Name', 'Description', 'Platform', 'Public?', 'ID'
           Silo.all.each do |s|
             table.row Paint[s.name, :cyan],
                       Paint[s.description, :green],
                       Paint[s.type.name, :cyan],
-                      s.is_public
+                      s.is_public,
+                      s.id.delete_prefix("flight-silo-").upcase
           end
           table.emit
         end

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -163,6 +163,7 @@ module FlightSilo
               data["files"]&.map { |f| File.basename(f) }]
     end
 
+<<<<<<< HEAD
     # TODO: change recursive arg to keyword
     def pull(source, dest, recursive)
       self.class.check_prepared(@type)
@@ -178,12 +179,16 @@ module FlightSilo
     end
 
     attr_reader :name, :type, :global, :description, :is_public, :creds, :id
+=======
+    attr_reader :name, :type, :global, :description, :is_public, :creds
+>>>>>>> 6635425 (Make `dir_exists` general)
 
     def initialize(global: false, md: {})
       @name = md.delete("name")
       @type = Type[md.delete("type")]
       @description = md.delete("description")
       @is_public = md.delete("is_public")
+<<<<<<< HEAD
       @id = md.delete("id")
       
       @creds = md # Credentials are all unused metadata values
@@ -193,6 +198,10 @@ module FlightSilo
 
     def run_action(*args, **kwargs)
       type.run_action(*args, **kwargs)
+=======
+      
+      @creds = md # Credentials are all unused metadata values
+>>>>>>> 6635425 (Make `dir_exists` general)
     end
   end
 end

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -177,7 +177,7 @@ module FlightSilo
       run_action('pull.sh', env: env)
     end
 
-    attr_reader :name, :type, :global, :description, :is_public, :creds
+    attr_reader :name, :type, :global, :description, :is_public, :creds, :id
 
     def initialize(global: false, md: {})
       @name = md.delete("name")

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -163,7 +163,6 @@ module FlightSilo
               data["files"]&.map { |f| File.basename(f) }]
     end
 
-<<<<<<< HEAD
     # TODO: change recursive arg to keyword
     def pull(source, dest, recursive)
       self.class.check_prepared(@type)
@@ -179,16 +178,12 @@ module FlightSilo
     end
 
     attr_reader :name, :type, :global, :description, :is_public, :creds, :id
-=======
-    attr_reader :name, :type, :global, :description, :is_public, :creds
->>>>>>> 6635425 (Make `dir_exists` general)
 
     def initialize(global: false, md: {})
       @name = md.delete("name")
       @type = Type[md.delete("type")]
       @description = md.delete("description")
       @is_public = md.delete("is_public")
-<<<<<<< HEAD
       @id = md.delete("id")
       
       @creds = md # Credentials are all unused metadata values
@@ -198,10 +193,6 @@ module FlightSilo
 
     def run_action(*args, **kwargs)
       type.run_action(*args, **kwargs)
-=======
-      
-      @creds = md # Credentials are all unused metadata values
->>>>>>> 6635425 (Make `dir_exists` general)
     end
   end
 end

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -28,10 +28,46 @@ module FlightSilo
         rescue NoSuchSiloError
           nil
         end
+      end
+      
+      def add(answers)
+        puts "Obtaining silo details for '#{answers["name"]}'..."
+        h = answers.clone
+        name = h.delete("name")
+        type = Type[h.delete("type")]
+        creds = h
+        
+        silo_id = get_silo(name: answers["name"], type: type, creds: creds)
 
-        silo = type.create(name: name, global: global)
+        if silo_id.empty?
+          raise "No silos found with given name."
+        end
 
-        set_default(silo) if default.nil?
+        env = {
+          'SILO_NAME' => silo_id,
+          'SILO_SOURCE' => 'cloud_metadata.yaml',
+          'SILO_DEST' => File.join(type.dir, 'cloud_metadata.yaml'),
+          'SILO_PUBLIC' => 'false',
+          'SILO_RECURSIVE' => 'false'
+        }.merge(creds)
+
+        type.run_action('pull.sh', env: env)
+
+        cloud_md = YAML.load_file("#{type.dir}/cloud_metadata.yaml")
+        `rm "#{type.dir}/cloud_metadata.yaml"`
+        `mkdir -p #{Config.user_silos_path}`
+        md = answers.merge(cloud_md).merge({"id" => silo_id})
+        File.open("#{Config.user_silos_path}/#{silo_id}.yaml", "w") { |file| file.write(md.to_yaml) }
+      end
+
+      # Takes a silo's friendly name and returns the id of the first accessible silo matching it
+      def get_silo(name:, type:, creds:)
+        check_prepared(type)
+        env = {
+          'SILO_NAME' => name
+        }.merge(creds)
+
+        type.run_action('get_silo.sh', env: env).chomp
       end
 
       def exists?(name)
@@ -53,6 +89,10 @@ module FlightSilo
           Config.user_data.set(:default_silo, value: silo.name)
           Config.save_user_data
         end
+      end
+
+      def check_prepared(type)
+        raise "Type '#{type.name}' is not prepared" unless type.prepared?
       end
 
       private
@@ -84,9 +124,9 @@ module FlightSilo
     end
 
     def dir_exists?(path)
-      check_prepared
+      self.class.check_prepared(@type)
       env = {
-        'SILO_NAME' => @name,
+        'SILO_NAME' => @id,
         'SILO_PUBLIC' => @is_public.to_s,
         'SILO_PATH' => path
       }.merge(@creds)
@@ -96,9 +136,9 @@ module FlightSilo
     end
 
     def file_exists?(path)
-      check_prepared
+      self.class.check_prepared(@type)
       env = {
-        'SILO_NAME' => @name,
+        'SILO_NAME' => @id,
         'SILO_PUBLIC' => @is_public.to_s,
         'SILO_PATH' => path
       }.merge(@creds)
@@ -108,9 +148,9 @@ module FlightSilo
     end
 
     def list(path)
-      check_prepared
+      self.class.check_prepared(@type)
       env = {
-        'SILO_NAME' => @name,
+        'SILO_NAME' => @id,
         'SILO_PUBLIC' => @is_public.to_s,
         'SILO_PATH' => path
       }.merge(@creds)
@@ -125,9 +165,9 @@ module FlightSilo
 
     # TODO: change recursive arg to keyword
     def pull(source, dest, recursive)
-      check_prepared
+      self.class.check_prepared(@type)
       env = {
-        'SILO_NAME' => @name,
+        'SILO_NAME' => @id,
         'SILO_SOURCE' => source,
         'SILO_DEST' => dest,
         'SILO_PUBLIC' => @is_public.to_s,
@@ -137,10 +177,6 @@ module FlightSilo
       run_action('pull.sh', env: env)
     end
 
-    def check_prepared
-      raise "Type '#{@type.name}' is not prepared" unless @type.prepared?
-    end
-
     attr_reader :name, :type, :global, :description, :is_public, :creds
 
     def initialize(global: false, md: {})
@@ -148,40 +184,15 @@ module FlightSilo
       @type = Type[md.delete("type")]
       @description = md.delete("description")
       @is_public = md.delete("is_public")
+      @id = md.delete("id")
       
       @creds = md # Credentials are all unused metadata values
     end
 
     private
 
-    def run_action(script, env: {})
-      script = File.join(type.dir, 'actions', script)
-      if File.exists?(script)
-        with_clean_env do
-          stdout, stderr, status = Open3.capture3(
-            env.merge({ 'SILO_TYPE_DIR' => type.dir }),
-            script
-          )
-
-          unless status.success?
-            raise <<~OUT
-            Error running action:
-            #{stderr.chomp}
-            OUT
-          end
-
-          return stdout
-        end
-      end
-    end
-
-    def with_clean_env(&block)
-      if Kernel.const_defined?(:OpenFlight) && OpenFlight.respond_to?(:with_standard_env)
-        OpenFlight.with_standard_env { block.call }
-      else
-        msg = Bundler.respond_to?(:with_unbundled_env) ? :with_unbundled_env : :with_clean_env
-        Bundler.__send__(msg) { block.call }
-      end
+    def run_action(*args, **kwargs)
+      type.run_action(*args, **kwargs)
     end
   end
 end

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -124,6 +124,7 @@ module FlightSilo
     end
 
     def dir_exists?(path)
+<<<<<<< HEAD
       self.class.check_prepared(@type)
       env = {
         'SILO_NAME' => @id,
@@ -161,10 +162,44 @@ module FlightSilo
 
       return [data["dirs"]&.map { |d| File.basename(d) },
               data["files"]&.map { |f| File.basename(f) }]
+=======
+      credentials = " " + @creds.values.join(" ")
+      check_prepared
+      ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
+      resp = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/dir_exists.sh #{@id} #{@is_public} #{path}#{credentials}`.chomp==yes
+    end
+
+    def file_exists?(path)
+      credentials = " " + @creds.values.join(" ")
+      check_prepared
+      ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
+      `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/file_exists.sh #{@id} #{@is_public} #{path}#{credentials}`.chomp=="yes"
+    end
+
+    def list(path)
+      credentials = " " + @creds.values.join(" ")
+      check_prepared
+      ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
+      response = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/list.sh #{@id} #{@is_public} #{path}#{credentials}`
+      
+      # Type-specific
+      data = JSON.load(response)
+      if data == nil
+        raise "Directory /#{path} is empty"
+      end
+      if data["Contents"]
+        files = data["Contents"]&.map{ |obj| File.basename(obj["Key"][6..-1]) }[1..-1]
+      end
+      if data["CommonPrefixes"]
+        dirs = data["CommonPrefixes"]&.map{ |obj| File.basename(obj["Prefix"][6..-1]) }
+      end
+      return [dirs, files]
+>>>>>>> 7eda519 (Move id work into own branch)
     end
 
     # TODO: change recursive arg to keyword
     def pull(source, dest, recursive)
+<<<<<<< HEAD
       self.class.check_prepared(@type)
       env = {
         'SILO_NAME' => @id,
@@ -175,6 +210,12 @@ module FlightSilo
       }.merge(@creds)
 
       run_action('pull.sh', env: env)
+=======
+      credentials = " " + @creds.values.join(" ")
+      check_prepared
+      ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
+      response = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/pull.sh #{@id} #{@is_public} #{source} #{dest} #{recursive}#{credentials}`
+>>>>>>> 7eda519 (Move id work into own branch)
     end
 
     attr_reader :name, :type, :global, :description, :is_public, :creds, :id

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -121,7 +121,7 @@ module FlightSilo
 
       return [data["dirs"]&.map { |d| File.basename(d) },
               data["files"]&.map { |f| File.basename(f) }]
-    end 
+    end
 
     # TODO: change recursive arg to keyword
     def pull(source, dest, recursive)

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -124,7 +124,6 @@ module FlightSilo
     end
 
     def dir_exists?(path)
-<<<<<<< HEAD
       self.class.check_prepared(@type)
       env = {
         'SILO_NAME' => @id,
@@ -162,44 +161,10 @@ module FlightSilo
 
       return [data["dirs"]&.map { |d| File.basename(d) },
               data["files"]&.map { |f| File.basename(f) }]
-=======
-      credentials = " " + @creds.values.join(" ")
-      check_prepared
-      ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-      resp = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/dir_exists.sh #{@id} #{@is_public} #{path}#{credentials}`.chomp==yes
-    end
-
-    def file_exists?(path)
-      credentials = " " + @creds.values.join(" ")
-      check_prepared
-      ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-      `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/file_exists.sh #{@id} #{@is_public} #{path}#{credentials}`.chomp=="yes"
-    end
-
-    def list(path)
-      credentials = " " + @creds.values.join(" ")
-      check_prepared
-      ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-      response = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/list.sh #{@id} #{@is_public} #{path}#{credentials}`
-      
-      # Type-specific
-      data = JSON.load(response)
-      if data == nil
-        raise "Directory /#{path} is empty"
-      end
-      if data["Contents"]
-        files = data["Contents"]&.map{ |obj| File.basename(obj["Key"][6..-1]) }[1..-1]
-      end
-      if data["CommonPrefixes"]
-        dirs = data["CommonPrefixes"]&.map{ |obj| File.basename(obj["Prefix"][6..-1]) }
-      end
-      return [dirs, files]
->>>>>>> 7eda519 (Move id work into own branch)
     end
 
     # TODO: change recursive arg to keyword
     def pull(source, dest, recursive)
-<<<<<<< HEAD
       self.class.check_prepared(@type)
       env = {
         'SILO_NAME' => @id,
@@ -210,12 +175,6 @@ module FlightSilo
       }.merge(@creds)
 
       run_action('pull.sh', env: env)
-=======
-      credentials = " " + @creds.values.join(" ")
-      check_prepared
-      ENV["flight_SILO_types"] = "#{Config.root}/etc/types"
-      response = `/bin/bash #{Config.root}/etc/types/#{@type.name}/actions/pull.sh #{@id} #{@is_public} #{source} #{dest} #{recursive}#{credentials}`
->>>>>>> 7eda519 (Move id work into own branch)
     end
 
     attr_reader :name, :type, :global, :description, :is_public, :creds, :id


### PR DESCRIPTION
AWS bucket names are globally unique, but silo names shouldn't also need to be globally unique. Instead of using the silo name as the bucket name, all silo buckets (and ideally all implementations of silos on any storage provider) will have the name `flight-silo-XXXXXXXX`, with the last 8 characters being a lower-case alphabetical string which is randomly assigned on silo creation. With a string of this length, we'd need to have created well over 100,000 different buckets for the odds of a collision to be even close to relevant, and with the changes to use `open3` for running scripts, we'll soon be able to specifically handle naming collision errors too.

The only bucket with a naming scheme not matching this format is the `openflight` bucket, which isn't inherently an issue although it could be remade if we'd rather have all IDs be of the same format. The new `add` command will still search for silo `name`, and will add the first silo with a matching name, taken from its `cloud_metadata` file in the root directory.