### PR TITLE
Rsync-style pulling for files

### DIFF
--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -62,7 +62,6 @@ module FlightSilo
         end
         parent = File.expand_path("..", dest)
         raise NoSuchDirectoryError, "Parent directory '#{parent}' not found" unless File.directory?(parent)
-
         puts "Pulling '#{silo.name}:#{source.delete_prefix("files")}' into '#{dest}'..."
 
         if @options.recursive

--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -64,6 +64,7 @@ module FlightSilo
         end
         parent = File.expand_path("..", dest)
         raise NoSuchDirectoryError, "Parent directory '#{parent}' not found" unless File.directory?(parent)
+
         puts "Pulling '#{silo.name}:#{source.delete_prefix("files")}' into '#{dest}'..."
 
         if @options.recursive

--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -48,7 +48,7 @@ module FlightSilo
         if args[1]
           dest = args[1]
         else
-          dest = Dir.pwd + "/"
+          dest = Dir.pwd
         end
 
         keep_parent = source[-1] == "/"
@@ -72,12 +72,12 @@ module FlightSilo
             `mkdir #{dest} >/dev/null 2>&1`
           else
             `mkdir #{dest} >/dev/null 2>&1`
-            dest = File.expand_path(dest + "/" + File.basename(source))
+            dest = File.expand_path(File.join(dest, File.basename(source)))
           end
         else
           if dest[-1] == "/"
             `mkdir #{dest} >/dev/null 2>&1`
-            dest = File.expand_path(dest + "/" + File.basename(source))
+            dest = File.expand_path(File.join(dest, File.basename(source)))
           end
         end
 

--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -48,10 +48,8 @@ module FlightSilo
         if args[1]
           dest = args[1]
         else
-          dest = Dir.pwd
+          dest = Dir.pwd + "/"
         end
-
-        keep_parent = @options.recursive && source[-1] == "/"
 
         silo = Silo[silo_name]
 
@@ -67,10 +65,24 @@ module FlightSilo
 
         puts "Pulling '#{silo.name}:#{source.delete_prefix("files")}' into '#{dest}'..."
 
-        `mkdir #{dest} >/dev/null 2>&1`
+        if @options.recursive
+          if source[-1] == "/"
+            `mkdir #{dest} >/dev/null 2>&1`
+          else
+            `mkdir #{dest} >/dev/null 2>&1`
+            dest = File.expand_path(dest + "/" + File.basename(source))
+          end
+        else
+          if dest[-1] == "/"
+            `mkdir #{dest} >/dev/null 2>&1`
+            dest = File.expand_path(dest + "/" + File.basename(source))
+          end
+        end
+
         dest = dest + "/" + File.basename(source) unless keep_parent
 
         silo.pull(source, dest, @options.recursive)
+
         puts "File(s) downloaded to #{dest}"
       end
     end

--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -51,6 +51,8 @@ module FlightSilo
           dest = Dir.pwd + "/"
         end
 
+        keep_parent = source[-1] == "/"
+
         silo = Silo[silo_name]
 
         if @options.recursive
@@ -65,7 +67,7 @@ module FlightSilo
         puts "Pulling '#{silo.name}:#{source.delete_prefix("files")}' into '#{dest}'..."
 
         if @options.recursive
-          if source[-1] == "/"
+          if keep_parent
             `mkdir #{dest} >/dev/null 2>&1`
           else
             `mkdir #{dest} >/dev/null 2>&1`
@@ -78,10 +80,7 @@ module FlightSilo
           end
         end
 
-        dest = dest + "/" + File.basename(source) unless keep_parent
-
         silo.pull(source, dest, @options.recursive)
-
         puts "File(s) downloaded to #{dest}"
       end
     end


### PR DESCRIPTION
This PR allows more control over how `file pull` works:

`file pull dir1/dir2/ /home/dir3` will pull the contents of `dir2` into `dir3`
`file pull dir1/dir2 /home/dir3` will pull the contents of `dir2` into `dir3/dir2`
`file pull dir1/file /Downloads/` will pull `file` into the `Downloads` directory
`file pull dir1/file /Downloads` will pull file into `/` and rename it `Downloads`

Essentially, a trailing slash refers to the contents of a directory, while the lack of a trailing slash refers to the item itself.

~This PR also updates the `dir_exists` action a little to make it more consistent and similar to the corresponding action on `develop`~