### PR TITLE
Implement delete command

### DIFF
--- a/etc/types/aws/actions/delete.sh
+++ b/etc/types/aws/actions/delete.sh
@@ -1,1 +1,4 @@
-echo "Deleting"
+test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
+test $SILO_RECURSIVE = "true" && recursive=--recursive || recursive=""
+object_uri="s3://$SILO_NAME/$SILO_PATH"
+$SILO_TYPE_DIR/cli/bin/aws s3 rm "$object_uri" $sign_request $recursive

--- a/etc/types/aws/actions/dir_exists.sh
+++ b/etc/types/aws/actions/dir_exists.sh
@@ -1,7 +1,7 @@
 test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
 list=$($SILO_TYPE_DIR/cli/bin/aws s3 ls s3://$SILO_NAME/$SILO_PATH $sign_request)
 
-if [ -z $list ]; then
+if [ -z "$list" ]; then
   echo "no"
 else
   echo "yes"

--- a/etc/types/aws/actions/list.sh
+++ b/etc/types/aws/actions/list.sh
@@ -9,7 +9,7 @@ directories=$($SILO_TYPE_DIR/cli/bin/aws s3api list-objects-v2 --bucket "$SILO_N
 echo "---"
 if [ "$files" != null ]; then
   echo "files:"
-  echo -e "$files" | sed 's/\t/\n- /g' | tail -n +2
+  echo -e "\t$files" | sed 's/\t/\n- /g'
 fi
 if [ "$directories" != "None" ]; then
   echo -e "dirs:"

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -98,6 +98,13 @@ module FlightSilo
       c.action Commands, :repo_list
     end
 
+    command 'file delete' do |c|
+      cli_syntax(c, 'REPO:FILE')
+      c.description = "Delete the specified file from the given silo repository"
+      c.action Commands, :file_delete
+      c.slop.bool "-r", "--recursive", "Delete a directory and all contents"
+    end
+
     command 'file list' do |c|
       cli_syntax(c, '[REPO:DIR]')
       c.description = "List user files in the specified directory"

--- a/lib/silo/commands/file_delete.rb
+++ b/lib/silo/commands/file_delete.rb
@@ -45,7 +45,8 @@ module FlightSilo
           target = args[0]
         end
 
-        raise "Silo '#{silo_name}' not found" unless silo = Silo[silo_name]
+        silo = Silo[silo_name]
+        raise NoSuchSiloError "Silo '#{silo_name}' not found" unless silo
 
         if @options.recursive
           target = File.join("files/", target.to_s.chomp("/"), "/")

--- a/lib/silo/commands/file_delete.rb
+++ b/lib/silo/commands/file_delete.rb
@@ -57,9 +57,10 @@ module FlightSilo
           raise NoSuchFileError, "Remote file '#{target.delete_prefix("files")}' not found (use --recursive to delete directories)" unless silo.file_exists?(target)
         end
 
-        puts "Deleting remote file '#{target.delete_prefix("files/")}'..."
+        target_type = @options.recursive ? 'directory' : 'file'
+        puts "Deleting remote #{target_type} '#{target.delete_prefix("files/")}'..."
         silo.delete(target, recursive: @options.recursive)
-        puts "Deleted remote file '#{target.delete_prefix("files/")}'"
+        puts "Deleted remote #{target_type} '#{target.delete_prefix("files/")}'"
       end
 
       def bold(string)

--- a/lib/silo/commands/file_delete.rb
+++ b/lib/silo/commands/file_delete.rb
@@ -57,7 +57,7 @@ module FlightSilo
         end
 
         puts "Deleting remote file '#{target.delete_prefix("files/")}'..."
-        silo.delete(target, @options.recursive)
+        silo.delete(target, recursive: @options.recursive)
         puts "Deleted remote file '#{target.delete_prefix("files/")}'"
       end
 

--- a/lib/silo/commands/file_delete.rb
+++ b/lib/silo/commands/file_delete.rb
@@ -45,7 +45,7 @@ module FlightSilo
           target = args[0]
         end
 
-        silo = Silo[silo_name]
+        raise "Silo '#{silo_name}' not found" unless silo = Silo[silo_name]
 
         if @options.recursive
           target = File.join("files/", target.to_s.chomp("/"), "/")

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -36,23 +36,20 @@ module FlightSilo
         # ARGS:
         # [silo:dir]
 
-        silo_name, dir = 
-          if args.empty?
-            [Silo.default, '']
-          elsif args[0].match(/^[^:]*:[^:]*$/)
-            str = args[0].split(":")
-            repo = str[0].empty? ? Silo.default : str[0]
-            dir = str[1]
-            
-            [repo, dir]
-          else
-            [Silo.default, args[0]]
-          end
+        if args[0]&.match(/^[^:]*:[^:]*$/)
+          silo_name, dir = args[0].split(":")
+        elsif args.empty?
+          silo_name, dir = Silo.default, '/'
+        else
+          silo_name = Silo.default
+          dir = args[0]
+        end
 
         silo = Silo[silo_name]
         raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
 
         dir = File.join("files/", dir.to_s.chomp("/"), "/")
+
 
         raise NoSuchDirectoryError, "Remote directory '#{dir.delete_prefix("/files")}' not found" unless silo.dir_exists?(dir)
         dirs, files = silo.list(dir)

--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -82,7 +82,7 @@ module FlightSilo
           end
         end
 
-        silo.pull(source, dest, @options.recursive)
+        silo.pull(source, dest, recursive: @options.recursive)
         puts "File(s) downloaded to #{dest}"
       end
     end

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -162,7 +162,7 @@ module FlightSilo
       resp == 'yes'
     end
 
-    def delete(path, recursive)
+    def delete(path, recursive: false)
       self.class.check_prepared(@type)
       env = {
         'SILO_NAME' => @id,
@@ -190,8 +190,7 @@ module FlightSilo
               data["files"]&.map { |f| File.basename(f) }]
     end
 
-    # TODO: change recursive arg to keyword
-    def pull(source, dest, recursive)
+    def pull(source, dest, recursive: false)
       self.class.check_prepared(@type)
       env = {
         'SILO_NAME' => @id,

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -162,6 +162,18 @@ module FlightSilo
       resp == 'yes'
     end
 
+    def delete(path, recursive)
+      self.class.check_prepared(@type)
+      env = {
+        'SILO_NAME' => @id,
+        'SILO_PUBLIC' => @is_public.to_s,
+        'SILO_PATH' => path,
+        'SILO_RECURSIVE' => recursive.to_s
+      }.merge(@creds)
+
+      run_action('delete.sh', env: env).chomp
+    end
+
     def list(path)
       self.class.check_prepared(@type)
       env = {


### PR DESCRIPTION
This PR is a fixed-up branch of the changes made on `dev/delete-file` - implementing the `file delete` command (for AWS only) which permits deletion of files which are in the `/files/` directory in the user's silo. The format for selecting files is the same as that used elsewhere in silo, `REPO:FILE`. The `--recursive` option must be used if a directory is being deleted, but deleting the `/files/` directory itself is prevented.