### PR TITLE
Repo remove command

### DIFF
--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -86,6 +86,12 @@ module FlightSilo
       c.action Commands, :repo_create
     end
 
+    command 'repo remove' do |c|
+      cli_syntax(c)
+      c.description = "Remove an existing silo from your system"
+      c.action Commands, :repo_remove
+    end
+
     command 'repo list' do |c|
       cli_syntax(c)
       c.description = "List available existing silos"

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -87,7 +87,7 @@ module FlightSilo
     end
 
     command 'repo remove' do |c|
-      cli_syntax(c)
+      cli_syntax(c, 'REPO')
       c.description = "Remove an existing silo from your system"
       c.action Commands, :repo_remove
     end

--- a/lib/silo/commands/repo_remove.rb
+++ b/lib/silo/commands/repo_remove.rb
@@ -37,9 +37,10 @@ module FlightSilo
     class RepoRemove < Command
       def run
         silo = Silo[@args[0]]
+        raise "Cannot remove public silos" if silo.is_public
 
         silo.remove
-        puts "Silo removed"
+        puts "Silo '#{silo.name}' removed"
       end
     end
   end

--- a/lib/silo/commands/repo_remove.rb
+++ b/lib/silo/commands/repo_remove.rb
@@ -24,39 +24,22 @@
 # For more information on Flight Silo, please visit:
 # https://github.com/openflighthpc/flight-silo
 #==============================================================================
-require_relative 'commands/type_avail'
-require_relative 'commands/type_prepare'
-require_relative 'commands/repo_add'
-require_relative 'commands/repo_create'
-require_relative 'commands/repo_remove'
-require_relative 'commands/repo_list'
-require_relative 'commands/file_list'
-require_relative 'commands/file_pull'
-require_relative 'commands/set_default'
+require_relative '../command'
+require_relative '../silo'
+require_relative '../type'
+
+require 'yaml'
+require 'open3'
+require 'tty-prompt'
 
 module FlightSilo
   module Commands
-    class << self
-      def method_missing(s, *a, &b)
-        if clazz = to_class(s)
-          clazz.new(*a).run!
-        else
-          raise 'command not defined'
-        end
-      end
+    class RepoRemove < Command
+      def run
+        silo = Silo[@args[0]]
 
-      def respond_to_missing?(s)
-        !!to_class(s)
-      end
-
-      private
-      def to_class(s)
-        s.to_s.split('-').reduce(self) do |clazz, p|
-          p.gsub!(/_(.)/) {|a| a[1].upcase}
-          clazz.const_get(p[0].upcase + p[1..-1])
-        end
-      rescue NameError
-        nil
+        silo.remove
+        puts "Silo removed"
       end
     end
   end

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -146,6 +146,10 @@ module FlightSilo
       resp == 'yes'
     end
 
+    def remove
+      File.delete("#{Config.user_silos_path}/#{name}.yaml")
+    end
+
     def file_exists?(path)
       self.class.check_prepared(@type)
       env = {

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -147,7 +147,7 @@ module FlightSilo
     end
 
     def remove
-      File.delete("#{Config.user_silos_path}/#{name}.yaml")
+      File.delete("#{Config.user_silos_path}/#{@id}.yaml")
     end
 
     def file_exists?(path)


### PR DESCRIPTION
This PR introduces the `repo remove` command. This command DOES NOT delete the silo, nor does it affect the upstream silo in any way. It exists as the opposite of `repo add`, in that it deletes the locally stored information about a given silo and removes it from the output of `repo list`. This command cannot be used on public silos.