### PR TITLE
Add concept of 'Softwares'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'open3'
 gem 'tty-prompt'
 gem 'tty-config'
 gem 'tty-table'
+gem 'activesupport'
 gem 'xdg', git: 'https://github.com/bkuhlmann/xdg', tag: '3.0.2'
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,22 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     ast (2.4.2)
     commander-openflighthpc (2.2.0)
       highline (> 1.7.2)
       paint (~> 2.1.0)
       slop (~> 4.8)
+    concurrent-ruby (1.2.2)
     highline (2.1.0)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
     json (2.6.3)
+    minitest (5.18.0)
     open3 (0.1.2)
     paint (2.1.1)
     parallel (1.22.1)
@@ -59,6 +68,8 @@ GEM
       pastel (~> 0.8)
       strings (~> 0.2.0)
       tty-screen (~> 0.8)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
     unicode_utils (1.4.0)
     wisper (2.0.1)
@@ -68,6 +79,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport
   commander-openflighthpc (~> 2.2.0)
   open3
   rubocop

--- a/README.md
+++ b/README.md
@@ -25,16 +25,56 @@ Flight Silo has some optional configuration settings available. A
 
 ## Operation
 
+### Setting up a silo
+
 Use `type avail` to list available provider types, and use `type prepare` to 
 prepare any required types.
 
-`repo avail` will list accessible silos. 
+`repo avail` will list accessible silos.
+
+`repo add` will add an existing silo to your system.
+
+`repo create` will create a silo for your chosen provider. You can then add
+your silo to other systems using the same credentials.
+
+`repo remove` will remove the silo metadata from your system, while
+`repo delete` will destroy the upstream silo (requiring confirmation to do so).
+
+### Interacting with files
 
 The `file list` and `file pull` commands can list and pull files respectively. 
 When specifying a file or directory in a silo, the format is `silo:path`, e.g. 
 `my-silo:/pictures/art.png`. If the silo name is not given, the default silo 
 will be used instead (the default silo may be changed in `config.yml`). If a 
 local file path is missing as an argument, the current working directory is used.
+
+Files and directories can be deleted from a silo with `file delete`. The
+`--recursive` option is required to delete directories.
+
+Files and directories can be pushed to a silo with `file push`. The
+specification for remote locations is the same as the `pull` command.
+
+### Interacting with softwares
+
+Flight Silo can store `.tar.gz` files, called "softwares", with a name and a
+version number attached to them.
+
+You can push a software to a silo with `software push FILE NAME VERSION`. The
+value given to `VERSION` must be a set of alphanumeric characters separated by 
+period characters. All characters preceding the first period (if it exists) must
+be integer digits. For example, the following version numbers are all valid:
+
+```
+1
+1.0
+0.1.0
+0.a
+1.1a
+```
+
+Once uploaded, softwares can be pulled onto any machine with access to the silo.
+The previously uploaded tarball will be downloaded and extracted to your given
+softwares directory.
 
 # Contributing
 

--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -9,3 +9,5 @@
 # Default silo to use when none is given
 #default_silo: flight-storage-test
 #
+# Directory to extract softwares to
+#software_dir:

--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -1,13 +1,13 @@
 ---
 # Path(s) where provider type metadata is stored
 #type_paths:
-#- "/opt/flight/opt/silo/etc/types"
+#- "/opt/flight/opt/silo/etc/types/"
 #
 # Path where global silos are stored
-#global_silos_path: "/opt/flight/opt/silo/etc/global"
+#global_silos_path: "/opt/flight/opt/silo/var/lib/silos/"
 #
 # Default silo to use when none is given
-#default_silo: flight-storage-test
+#default_silo: openflight
 #
 # Directory to extract softwares to
-#software_dir:
+#software_dir: ~/.local/share/flight/silo/software/

--- a/etc/types/aws/actions/list.sh
+++ b/etc/types/aws/actions/list.sh
@@ -1,15 +1,20 @@
-set -e
-
 test $SILO_PUBLIC = true && sign_request=--no-sign-request || sign_request=""
 
-files=$($SILO_TYPE_DIR/cli/bin/aws s3api list-objects-v2 --bucket "$SILO_NAME" --prefix "$SILO_PATH" --delimiter / --output text --query Contents[:].Key $sign_request)
+files=$($SILO_TYPE_DIR/cli/bin/aws s3api list-objects-v2 --bucket "$SILO_NAME" --prefix "$SILO_PATH" --delimiter / --output text --query 'Contents[:].{ Name: Key, Size: Size}' $sign_request)
 
 directories=$($SILO_TYPE_DIR/cli/bin/aws s3api list-objects-v2 --bucket "$SILO_NAME" --prefix "$SILO_PATH" --delimiter / --output text --query CommonPrefixes[:].Prefix $sign_request)
 
+
 echo "---"
 if [ "$files" != null ]; then
+  files=${files#*$'\n'}
   echo "files:"
-  echo -e "$files" | sed 's/\t/\n- /g' | tail -n +2
+
+  val=1
+  for item in $(echo -e "$files") ; do
+      (( $val )) && echo "- name: $item" || echo "  size: $item"
+      ((val ^= 1))
+  done
 fi
 if [ "$directories" != "None" ]; then
   echo -e "dirs:"

--- a/etc/types/aws/actions/list.sh
+++ b/etc/types/aws/actions/list.sh
@@ -11,7 +11,7 @@ if [ "$files" != null ]; then
   val=1
   skipnext=false
   for item in $(echo -e "$files") ; do
-    if [[ "$item" == "files/" ]] ; then
+    if [[ "$item" == "files/" ]] || [[ "$item" == "software/" ]]; then
       ((val ^= 1))
       skipnext=true
       continue

--- a/etc/types/aws/actions/print_file.sh
+++ b/etc/types/aws/actions/print_file.sh
@@ -1,0 +1,5 @@
+set -e
+
+test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
+object_uri="s3://$SILO_NAME/$SILO_SOURCE"
+$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" -  $sign_request $recursive

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -154,5 +154,12 @@ module FlightSilo
       c.slop.boolean '--overwrite', 'Overwrite software locally if it exists'
       c.action Commands, :software_pull
     end
+
+    command 'software delete' do |c|
+      cli_syntax(c, 'NAME VERSION')
+      c.description = "Delete a software binary from a silo"
+      c.slop.string '--repo', 'Override default silo'
+      c.action Commands, :software_delete
+    end
   end
 end

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -151,6 +151,7 @@ module FlightSilo
       cli_syntax(c, 'NAME VERSION')
       c.description = "Pull a software binary from a silo to your apps directory"
       c.slop.string '--repo', 'Override default silo'
+      c.slop.boolean '--overwrite', 'Overwrite software locally if it exists'
       c.action Commands, :software_pull
     end
   end

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -139,7 +139,7 @@ module FlightSilo
     end
 
     command 'software push' do |c|
-      cli_syntax(c, 'SOFTWARE')
+      cli_syntax(c, 'FILE NAME VERSION')
       c.description = "Push a software binary to a silo"
       c.slop.string '--repo', 'Override default silo'
       c.action Commands, :software_push

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -132,10 +132,11 @@ module FlightSilo
       c.slop.bool "--make-parent", "Create subdirectories upstream if they don't exist"
     end
 
-    command 'software list' do |c|
-      cli_syntax(c, '[REPO]')
+    command 'software search' do |c|
+      cli_syntax(c, '[NAME]')
       c.description = "List software binaries in a silo"
-      c.action Commands, :software_list
+      c.slop.string '--repo', 'Override default silo'
+      c.action Commands, :software_search
     end
 
     command 'software push' do |c|

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -131,5 +131,11 @@ module FlightSilo
       c.slop.bool "-r", "--recursive", "Push a directory and all contents"
       c.slop.bool "--make-parent", "Create subdirectories upstream if they don't exist"
     end
+
+    command 'software list' do |c|
+      cli_syntax(c, '[REPO]')
+      c.description = "List software binaries in a silo"
+      c.action Commands, :software_list
+    end
   end
 end

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -143,6 +143,7 @@ module FlightSilo
       cli_syntax(c, 'FILE NAME VERSION')
       c.description = "Push a software binary to a silo"
       c.slop.string '--repo', 'Override default silo'
+      c.slop.bool '--force', 'Overwrite existing software version'
       c.action Commands, :software_push
     end
 

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -144,5 +144,12 @@ module FlightSilo
       c.slop.string '--repo', 'Override default silo'
       c.action Commands, :software_push
     end
+
+    command 'software pull' do |c|
+      cli_syntax(c, 'NAME VERSION')
+      c.description = "Pull a software binary from a silo to your apps directory"
+      c.slop.string '--repo', 'Override default silo'
+      c.action Commands, :software_pull
+    end
   end
 end

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -118,7 +118,7 @@ module FlightSilo
     end
 
     command 'file pull' do |c|
-      cli_syntax(c, 'REPO:SOURCE, [DEST]')
+      cli_syntax(c, 'REPO:SOURCE [DEST]')
       c.description = "Download a file from a silo to this machine"
       c.action Commands, :file_pull
       c.slop.bool "-r", "--recursive", "Pull a directory and all contents"
@@ -136,6 +136,13 @@ module FlightSilo
       cli_syntax(c, '[REPO]')
       c.description = "List software binaries in a silo"
       c.action Commands, :software_list
+    end
+
+    command 'software push' do |c|
+      cli_syntax(c, 'SOFTWARE')
+      c.description = "Push a software binary to a silo"
+      c.slop.string '--repo', 'Override default silo'
+      c.action Commands, :software_push
     end
   end
 end

--- a/lib/silo/commands.rb
+++ b/lib/silo/commands.rb
@@ -35,9 +35,9 @@ require_relative 'commands/file_delete'
 require_relative 'commands/file_list'
 require_relative 'commands/file_pull'
 require_relative 'commands/file_push'
-require_relative 'commands/software_list'
 require_relative 'commands/software_pull'
 require_relative 'commands/software_push'
+require_relative 'commands/software_search'
 require_relative 'commands/set_default'
 
 module FlightSilo

--- a/lib/silo/commands.rb
+++ b/lib/silo/commands.rb
@@ -36,6 +36,7 @@ require_relative 'commands/file_list'
 require_relative 'commands/file_pull'
 require_relative 'commands/file_push'
 require_relative 'commands/software_list'
+require_relative 'commands/software_pull'
 require_relative 'commands/software_push'
 require_relative 'commands/set_default'
 

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -57,7 +57,7 @@ module FlightSilo
         dirs&.each do |dir|
           puts Paint[bold(dir), :blue]
         end
-        puts files if files
+        puts files.map(&:name) if files
       end
 
       def bold(string)

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -57,7 +57,7 @@ module FlightSilo
         dirs&.each do |dir|
           puts Paint[bold(dir), :blue]
         end
-        puts files.map(&:name) if files
+        puts files.map { |f| f[:name] } if files
       end
 
       def bold(string)

--- a/lib/silo/commands/file_push.rb
+++ b/lib/silo/commands/file_push.rb
@@ -47,6 +47,8 @@ module FlightSilo
           dest = args[1] || ''
         end
 
+        dest ||= ''
+
         silo = Silo[silo_name]
         raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
 
@@ -75,7 +77,7 @@ module FlightSilo
             raise NoSuchFileError, error
           end
 
-          if dest[-1] =='/' || dest.empty?
+          if dest.empty? || dest[-1] =='/'
             target = File.join('files', dest.squeeze('/'), File.basename(source))
           else
             target = File.join('files', dest.squeeze('/'))

--- a/lib/silo/commands/software_delete.rb
+++ b/lib/silo/commands/software_delete.rb
@@ -41,26 +41,26 @@ module FlightSilo
         # OPTS:
         # [repo]
 
-        @name, @version = args
+        name, version = args
 
         raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
 
         raise "Public silos cannot be modified." if silo.is_public
 
-        unless silo.find_software(@name, @version)
-          raise "Software '#{@name}' version '#{@version}' not found"
+        unless silo.find_software(name, version)
+          raise "Software '#{name}' version '#{version}' not found"
         end
 
         software_path = File.join(
           'software',
-          "#{@name}~#{@version}.software"
+          "#{name}~#{version}.software"
         )
 
-        puts "Deleting software '#{@name}' version '#{@version}'..."
+        puts "Deleting software '#{name}' version '#{version}'..."
 
         silo.delete(software_path)
 
-        puts "Deleted software '#{@name}' version '#{@version}'."
+        puts "Deleted software '#{name}' version '#{version}'."
       end
 
       private

--- a/lib/silo/commands/software_list.rb
+++ b/lib/silo/commands/software_list.rb
@@ -47,10 +47,6 @@ module FlightSilo
       def silo
         Silo[args[0] || Silo.default]
       end
-
-      def bold(string)
-        "\e[1m#{string}\e[22m"
-      end
     end
   end
 end

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -41,37 +41,37 @@ module FlightSilo
         # OPTS:
         # [ repo ]
 
-        @name, @version = args
+        name, version = args
 
         raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
 
-        unless silo.find_software(@name, @version)
-          raise "Software '#{@name}' version '#{@version}' not found"
+        unless silo.find_software(name, version)
+          raise "Software '#{name}' version '#{version}' not found"
         end
 
         software_path = File.join(
           'software',
-          "#{join_software_name(delimiter: '~')}.software"
+          "#{name}~#{version}.software"
         )
 
         tmp_path = File.join(
           '/tmp',
-          join_software_name(random_string, delimiter: '~')
+          "#{name}~#{version}~#{random_string}"
         )
 
         extract_path = File.join(
           Config.user_software_dir,
-          @name,
-          @version
+          name,
+          version
         )
 
         # Check that the software doesn't already exist locally
         if !@options.overwrite && File.directory?(extract_path)
-          raise "Already exists: '#{@name}' version '#{@version}' at path '#{extract_path}'"
+          raise "Already exists: '#{name}' version '#{version}' at path '#{extract_path}'"
         end
 
         # Pull software to /tmp
-        puts "Downloading software '#{@name}' version '#{@version}'..."
+        puts "Downloading software '#{name}' version '#{version}'..."
 
         silo.pull(software_path, tmp_path)
 
@@ -80,7 +80,7 @@ module FlightSilo
 
         extract_tar_gz(tmp_path, extract_path, mkdir_p: true)
 
-        puts "Extracted software '#{@name}' version '#{@version} to '#{Config.user_software_dir}'..."
+        puts "Extracted software '#{name}' version '#{version} to '#{Config.user_software_dir}'..."
       ensure
         FileUtils.rm(tmp_path) if File.file?(tmp_path)
       end
@@ -89,10 +89,6 @@ module FlightSilo
 
       def random_string(len=8)
         ('a'..'z').to_a.shuffle[0,len].join
-      end
-
-      def join_software_name(*extras, delimiter: '-')
-        (args + extras).join(delimiter)
       end
 
       def silo_name

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -67,7 +67,10 @@ module FlightSilo
 
         # Check that the software doesn't already exist locally
         if !@options.overwrite && File.directory?(extract_path)
-          raise "Already exists: '#{name}' version '#{version}' at path '#{extract_path}'"
+          raise <<~ERROR.chomp
+
+          Already exists: '#{name}' version '#{version}' at path '#{extract_path}' (use --overwrite to bypass)
+          ERROR
         end
 
         # Pull software to /tmp

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -65,7 +65,9 @@ module FlightSilo
         # Extract software to software dir
         puts "Extracting software to '#{Config.software_dir}'..."
 
-        extract_tar_gz(tmp_path, Config.software_dir, mkdir_p: true)
+        extract_path = File.join(Config.software_dir, args[0], args[1])
+
+        extract_tar_gz(tmp_path, extract_path, mkdir_p: true)
       ensure
         FileUtils.rm(tmp_path) if File.file?(tmp_path)
       end

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -1,0 +1,92 @@
+#==============================================================================
+# Copyright (C) 2023-present Alces Flight Ltd.
+#
+# This file is part of Flight Silo.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Silo is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Silo. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Silo, please visit:
+# https://github.com/openflighthpc/flight-silo
+#==============================================================================
+require_relative '../command'
+require_relative '../silo'
+require_relative '../tar_utils'
+require 'json'
+
+module FlightSilo
+  module Commands
+    class SoftwarePull < Command
+      include TarUtils
+
+      def run
+        # ARGS:
+        # [software, version]
+        #
+        # OPTS:
+        # [ repo ]
+
+        raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
+
+        unless silo.find_software(args[0], args[1])
+          raise "Software '#{join_software_name}' not found"
+        end
+
+        # Pull software to /tmp
+        puts "Downloading software '#{join_software_name}'..."
+
+        software_path = File.join(
+          'software',
+          "#{join_software_name(delimiter: '~')}.software"
+        )
+
+        tmp_path = File.join(
+          '/tmp',
+          join_software_name(random_string, delimiter: '~')
+        )
+
+        silo.pull(software_path, tmp_path)
+
+        # Extract software to software dir
+        puts "Extracting software to '#{Config.software_dir}'..."
+
+        extract_tar_gz(tmp_path, Config.software_dir, mkdir_p: true)
+      ensure
+        FileUtils.rm(tmp_path) if File.file?(tmp_path)
+      end
+
+      private
+
+      def random_string(len=8)
+        ('a'..'z').to_a.shuffle[0,len].join
+      end
+
+      def join_software_name(*extras, delimiter: '-')
+        (args + extras).join(delimiter)
+      end
+
+      def silo_name
+        @silo_name ||= @options.repo || Silo.default
+      end
+
+      def silo
+        @silo ||= Silo[silo_name]
+      end
+    end
+  end
+end

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -63,9 +63,9 @@ module FlightSilo
         silo.pull(software_path, tmp_path)
 
         # Extract software to software dir
-        puts "Extracting software to '#{Config.software_dir}'..."
+        puts "Extracting software to '#{Config.user_software_dir}'..."
 
-        extract_path = File.join(Config.software_dir, args[0], args[1])
+        extract_path = File.join(Config.user_software_dir, args[0], args[1])
 
         extract_tar_gz(tmp_path, extract_path, mkdir_p: true)
       ensure

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -46,7 +46,7 @@ module FlightSilo
         raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
 
         unless silo.find_software(@name, @version)
-          raise "Software '#{join_software_name}' not found"
+          raise "Software '#{@name}' version '#{@version}' not found"
         end
 
         software_path = File.join(
@@ -67,11 +67,11 @@ module FlightSilo
 
         # Check that the software doesn't already exist locally
         if !@options.overwrite && File.directory?(extract_path)
-          raise "Already exists: '#{join_software_name}' at path '#{extract_path}'"
+          raise "Already exists: '#{@name}' version '#{@version}' at path '#{extract_path}'"
         end
 
         # Pull software to /tmp
-        puts "Downloading software '#{join_software_name}'..."
+        puts "Downloading software '#{@name}' version '#{@version}'..."
 
         silo.pull(software_path, tmp_path)
 
@@ -79,6 +79,8 @@ module FlightSilo
         puts "Extracting software to '#{Config.user_software_dir}'..."
 
         extract_tar_gz(tmp_path, extract_path, mkdir_p: true)
+
+        puts "Extracted software '#{@name}' version '#{@version} to '#{Config.user_software_dir}'..."
       ensure
         FileUtils.rm(tmp_path) if File.file?(tmp_path)
       end

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -41,14 +41,13 @@ module FlightSilo
         # OPTS:
         # [ repo ]
 
+        @name, @version = args
+
         raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
 
-        unless silo.find_software(args[0], args[1])
+        unless silo.find_software(@name, @version)
           raise "Software '#{join_software_name}' not found"
         end
-
-        # Pull software to /tmp
-        puts "Downloading software '#{join_software_name}'..."
 
         software_path = File.join(
           'software',
@@ -60,12 +59,24 @@ module FlightSilo
           join_software_name(random_string, delimiter: '~')
         )
 
+        extract_path = File.join(
+          Config.user_software_dir,
+          @name,
+          @version
+        )
+
+        # Check that the software doesn't already exist locally
+        if !@options.overwrite && File.directory?(extract_path)
+          raise "Already exists: '#{join_software_name}' at path '#{extract_path}'"
+        end
+
+        # Pull software to /tmp
+        puts "Downloading software '#{join_software_name}'..."
+
         silo.pull(software_path, tmp_path)
 
         # Extract software to software dir
         puts "Extracting software to '#{Config.user_software_dir}'..."
-
-        extract_path = File.join(Config.user_software_dir, args[0], args[1])
 
         extract_tar_gz(tmp_path, extract_path, mkdir_p: true)
       ensure

--- a/lib/silo/commands/software_push.rb
+++ b/lib/silo/commands/software_push.rb
@@ -50,7 +50,7 @@ module FlightSilo
           raise "Invalid target; must end with '.tar.gz': #{software_path}"
         end
 
-        name, version = args[1..2].map(&:downcase)
+        name, version = args[1..2]
 
         unless name.match(/^[a-zA-Z0-9\-]+$/)
           raise "Software name must contain only alphanumeric characters and hyphens."

--- a/lib/silo/commands/software_push.rb
+++ b/lib/silo/commands/software_push.rb
@@ -46,7 +46,9 @@ module FlightSilo
 
         raise "Public silos cannot be pushed to." if silo.is_public
 
-        raise "Invalid tarball: #{software_path}" unless valid_tar_gz?(software_path)
+        unless File.basename(software_path).ends_with?('.tar.gz')
+          raise "Invalid target; must end with '.tar.gz': #{software_path}"
+        end
 
         name, version = args[1..2]
 

--- a/lib/silo/commands/software_push.rb
+++ b/lib/silo/commands/software_push.rb
@@ -65,7 +65,10 @@ module FlightSilo
         upstream_name = "#{name}~#{version}.software"
 
         if !@options.force && silo.find_software(name, version)
-          raise "Already exists: '#{name}' version '#{version}' on silo '#{silo_name}'"
+          raise <<~ERROR.chomp
+
+          raise "Already exists: '#{name}' version '#{version}' on silo '#{silo_name}' (use --force to bypass)
+          ERROR
         end
 
         puts "Uploading software '#{name}' version '#{version}'..."

--- a/lib/silo/commands/software_push.rb
+++ b/lib/silo/commands/software_push.rb
@@ -43,6 +43,9 @@ module FlightSilo
 
         raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
         raise NoSuchFileError, "File '#{args[0]}' not found" unless software_path
+
+        raise "Public silos cannot be pushed to." if silo.is_public
+
         raise "Invalid tarball: #{software_path}" unless valid_tar_gz?(software_path)
 
         name, version = args[1..2]
@@ -59,10 +62,14 @@ module FlightSilo
 
         upstream_name = "#{name}~#{version}.software"
 
+        puts "Uploading software '#{name}-#{version}'..."
+
         silo.push(
           software_path,
           "software/#{upstream_name}"
         )
+
+        puts "Uploaded software '#{name}-#{version}'."
       end
 
       private

--- a/lib/silo/commands/software_push.rb
+++ b/lib/silo/commands/software_push.rb
@@ -50,7 +50,7 @@ module FlightSilo
           raise "Invalid target; must end with '.tar.gz': #{software_path}"
         end
 
-        name, version = args[1..2]
+        name, version = args[1..2].map(&:downcase)
 
         unless name.match(/^[a-zA-Z0-9\-]+$/)
           raise "Software name must contain only alphanumeric characters and hyphens."

--- a/lib/silo/commands/software_push.rb
+++ b/lib/silo/commands/software_push.rb
@@ -46,7 +46,7 @@ module FlightSilo
 
         raise "Public silos cannot be pushed to." if silo.is_public
 
-        unless File.basename(software_path).ends_with?('.tar.gz')
+        unless File.basename(software_path).end_with?('.tar.gz')
           raise "Invalid target; must end with '.tar.gz': #{software_path}"
         end
 

--- a/lib/silo/commands/software_push.rb
+++ b/lib/silo/commands/software_push.rb
@@ -64,6 +64,10 @@ module FlightSilo
 
         upstream_name = "#{name}~#{version}.software"
 
+        if !@options.force && silo.find_software(name, version)
+          raise "Already exists: '#{name}-#{version}' on silo '#{silo_name}'"
+        end
+
         puts "Uploading software '#{name}-#{version}'..."
 
         silo.push(

--- a/lib/silo/commands/software_push.rb
+++ b/lib/silo/commands/software_push.rb
@@ -65,17 +65,17 @@ module FlightSilo
         upstream_name = "#{name}~#{version}.software"
 
         if !@options.force && silo.find_software(name, version)
-          raise "Already exists: '#{name}-#{version}' on silo '#{silo_name}'"
+          raise "Already exists: '#{name}' version '#{version}' on silo '#{silo_name}'"
         end
 
-        puts "Uploading software '#{name}-#{version}'..."
+        puts "Uploading software '#{name}' version '#{version}'..."
 
         silo.push(
           software_path,
           "software/#{upstream_name}"
         )
 
-        puts "Uploaded software '#{name}-#{version}'."
+        puts "Uploaded software '#{name}' version '#{version}'."
       end
 
       private

--- a/lib/silo/commands/software_search.rb
+++ b/lib/silo/commands/software_search.rb
@@ -52,8 +52,12 @@ module FlightSilo
 
       private
 
+      def silo_name
+        @options.repo || Silo.default
+      end
+
       def silo
-        Silo[@options.repo || Silo.default]
+        Silo[silo_name]
       end
     end
   end

--- a/lib/silo/commands/software_search.rb
+++ b/lib/silo/commands/software_search.rb
@@ -45,6 +45,8 @@ module FlightSilo
           version_depth: args[0] ? :all : nil
         }.reject { |k,v| v.nil? }
 
+        raise "No softwares found" if softwares.empty?
+
         puts "Showing latest 5 versions..." unless args[0]
 
         Software.table_from(softwares, **kwargs).emit

--- a/lib/silo/config.rb
+++ b/lib/silo/config.rb
@@ -113,14 +113,26 @@ module FlightSilo
         @public_silos_path ||= File.join(Config.root, 'etc', 'public_silos')
       end
 
-      def software_dir
-        @software_dir ||= File.expand_path(
+      def global_software_dir
+        @global_software_dir ||= File.expand_path(
           data.fetch(
             :software_dir,
             default: File.join(xdg_data.home, SILO_DIR_SUFFIX, 'software')
           ),
           Config.root
         )
+      end
+
+      def user_software_dir
+        @user_software_dir ||= 
+          ENV['flight_SILO_software_dir'] ||
+            File.expand_path(
+              user_data.fetch(
+                :software_dir,
+                default: global_software_dir
+              ),
+              Config.root
+            )
       end
 
       private

--- a/lib/silo/config.rb
+++ b/lib/silo/config.rb
@@ -103,7 +103,7 @@ module FlightSilo
         @global_silos_path ||= File.expand_path(
           data.fetch(
             :global_silos_path,
-            default: 'var/lib/silo'
+            default: 'var/lib/silos'
           ),
           Config.root
         )

--- a/lib/silo/config.rb
+++ b/lib/silo/config.rb
@@ -113,6 +113,16 @@ module FlightSilo
         @public_silos_path ||= File.join(Config.root, 'etc', 'public_silos')
       end
 
+      def software_dir
+        @software_dir ||= File.expand_path(
+          data.fetch(
+            :software_dir,
+            default: File.join(xdg_data.home, SILO_DIR_SUFFIX, 'software')
+          ),
+          Config.root
+        )
+      end
+
       private
 
       def xdg_config

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -136,18 +136,13 @@ module FlightSilo
     end
 
     def software_index
-      json = JSON.parse(print_file("software/index.json"))
+      _, softwares = list('software/')
+      softwares = softwares.to_a
 
-      json.map do |name, v|
-        v['versions'].map do |version, metadata|
-          Software.new(
-            name: name,
-            filename: metadata['filename'],
-            description: v['description'],
-            version: version
-          )
-        end
-      end.flatten
+      softwares.map do |software|
+        name, version = software.delete_suffix('.software').split('~')
+        Software.new(name: name, version: version)
+      end.sort_by { |s| [s.name, s.version] }
     end
 
     def dir_exists?(path)

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -145,6 +145,14 @@ module FlightSilo
       end.sort_by { |s| [s.name, s.version] }
     end
 
+    def find_software(software, version)
+      software_index.find do |s|
+        # Versions must be converted to strings because Gem::Version considers
+        # 1.0 and 1.0.0 to be equivalent
+        s.name == software && s.version.to_s == version.to_s
+      end
+    end
+
     def dir_exists?(path)
       self.class.check_prepared(@type)
       env = {

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -1,4 +1,5 @@
 require 'silo/errors'
+require 'silo/software'
 require 'yaml'
 
 module FlightSilo
@@ -202,7 +203,18 @@ module FlightSilo
     end
 
     def software_index
-      JSON.parse(print_file("software/index.json"))
+      json = JSON.parse(print_file("software/index.json"))
+
+      json.map do |name, v|
+        v['versions'].map do |version, metadata|
+          Software.new(
+            name: name,
+            filename: metadata['filename'],
+            description: v['description'],
+            version: version
+          )
+        end
+      end.flatten
     end
 
     def pull(source, dest, recursive: false)

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -135,6 +135,21 @@ module FlightSilo
       end
     end
 
+    def software_index
+      json = JSON.parse(print_file("software/index.json"))
+
+      json.map do |name, v|
+        v['versions'].map do |version, metadata|
+          Software.new(
+            name: name,
+            filename: metadata['filename'],
+            description: v['description'],
+            version: version
+          )
+        end
+      end.flatten
+    end
+
     def dir_exists?(path)
       self.class.check_prepared(@type)
       env = {
@@ -200,21 +215,6 @@ module FlightSilo
       }.merge(@creds)
 
       run_action('print_file.sh', env: env).chomp
-    end
-
-    def software_index
-      json = JSON.parse(print_file("software/index.json"))
-
-      json.map do |name, v|
-        v['versions'].map do |version, metadata|
-          Software.new(
-            name: name,
-            filename: metadata['filename'],
-            description: v['description'],
-            version: version
-          )
-        end
-      end.flatten
     end
 
     def pull(source, dest, recursive: false)

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -190,6 +190,21 @@ module FlightSilo
               data["files"]&.map { |f| File.basename(f) }]
     end
 
+    def print_file(file)
+      self.class.check_prepared(@type)
+      env = {
+        'SILO_NAME' => @id,
+        'SILO_SOURCE' => file,
+        'SILO_PUBLIC' => @is_public.to_s
+      }.merge(@creds)
+
+      run_action('print_file.sh', env: env).chomp
+    end
+
+    def software_index
+      JSON.parse(print_file("software/index.json"))
+    end
+
     def pull(source, dest, recursive: false)
       self.class.check_prepared(@type)
       env = {

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -140,8 +140,10 @@ module FlightSilo
       softwares = softwares.to_a
 
       softwares.map do |software|
-        name, version = software.delete_suffix('.software').split('~')
-        Software.new(name: name, version: version)
+        name, version = software[:name].delete_suffix('.software').split('~')
+        size = software[:size]
+
+        Software.new(name: name, version: version, filesize: size)
       end.sort_by { |s| [s.name, s.version] }
     end
 
@@ -205,8 +207,10 @@ module FlightSilo
 
       data = YAML.load(resp)
 
-      return [data["dirs"]&.map { |d| File.basename(d) },
-              data["files"]&.map { |f| File.basename(f) }]
+      return [
+        data["dirs"]&.map { |d| File.basename(d) },
+        data["files"]&.map { |f| { name: File.basename(f['name']), size:f['size'] } }
+      ]
     end
 
     def print_file(file)

--- a/lib/silo/software.rb
+++ b/lib/silo/software.rb
@@ -1,0 +1,36 @@
+require 'silo/errors'
+require 'yaml'
+require 'json'
+
+module FlightSilo
+  class Software
+    include Comparable
+
+    # Required for Comparable module
+    def <=>(software)
+      version <=> software.version
+    end
+
+    def to_table_row
+      [Paint[name, :cyan], version]
+    end
+
+    def dump_metadata
+      {
+        "name" => name,
+        "description" => description,
+        "version" => version.to_s,
+        "filename" => filename
+      }.to_json
+    end
+
+    attr_reader :name, :filename, :description, :version
+
+    def initialize(name:, filename:, description: '', version:)
+      @name = name
+      @filename = filename
+      @description = description
+      @version = Gem::Version.new(version)
+    end
+  end
+end

--- a/lib/silo/software.rb
+++ b/lib/silo/software.rb
@@ -30,18 +30,14 @@ module FlightSilo
     def dump_metadata
       {
         "name" => name,
-        "description" => description,
-        "version" => version.to_s,
-        "filename" => filename
+        "version" => version.to_s
       }.to_json
     end
 
-    attr_reader :name, :filename, :description, :version
+    attr_reader :name, :version
 
-    def initialize(name:, filename:, description: '', version:)
+    def initialize(name:, version:)
       @name = name
-      @filename = filename
-      @description = description
       @version = Gem::Version.new(version)
     end
   end

--- a/lib/silo/software.rb
+++ b/lib/silo/software.rb
@@ -11,7 +11,13 @@ module FlightSilo
       def table_from(softwares=[], version_depth: 5)
         grouped = softwares.group_by(&:name)
         latest = grouped.map do |k,v|
-          { k => v.sort_by(&:version).reverse.last(version_depth) }
+          versions = v.sort_by(&:version).reverse
+          case version_depth
+          when :all
+            { k => versions }
+          else
+            { k => versions.first(version_depth) }
+          end
         end.reduce({}, :merge)
 
         Table.new.tap do |t|

--- a/lib/silo/software.rb
+++ b/lib/silo/software.rb
@@ -63,7 +63,7 @@ module FlightSilo
 
     attr_reader :name, :version
 
-    def initialize(name:, version:)
+    def initialize(name:, version:, filesize: nil)
       @name = name
       @version = Gem::Version.new(version)
     end

--- a/lib/silo/software.rb
+++ b/lib/silo/software.rb
@@ -24,7 +24,7 @@ module FlightSilo
     end
 
     def to_table_row
-      [Paint[name, :cyan], version.to_s]
+      [bold(Paint[name, :cyan]), version.to_s]
     end
 
     def dump_metadata
@@ -39,6 +39,12 @@ module FlightSilo
     def initialize(name:, version:)
       @name = name
       @version = Gem::Version.new(version)
+    end
+
+    private
+
+    def bold(string)
+      "\e[1m#{string}\e[22m"
     end
   end
 end

--- a/lib/silo/software.rb
+++ b/lib/silo/software.rb
@@ -1,4 +1,5 @@
 require 'silo/errors'
+require 'silo/table'
 require 'yaml'
 require 'json'
 
@@ -6,13 +7,24 @@ module FlightSilo
   class Software
     include Comparable
 
+    class << self
+      def table_from(softwares=[])
+        Table.new.tap do |t|
+          t.headers 'Name', 'Version'
+          softwares.each do |s|
+            t.row *s.to_table_row
+          end
+        end
+      end
+    end
+
     # Required for Comparable module
     def <=>(software)
       version <=> software.version
     end
 
     def to_table_row
-      [Paint[name, :cyan], version]
+      [Paint[name, :cyan], version.to_s]
     end
 
     def dump_metadata

--- a/lib/silo/software.rb
+++ b/lib/silo/software.rb
@@ -14,16 +14,27 @@ module FlightSilo
           versions = v.sort_by(&:version).reverse
           case version_depth
           when :all
-            { k => versions }
+            [ { name: k, versions: versions } ]
           else
-            { k => versions.first(version_depth) }
+            [ { name: k, versions: versions.first(version_depth) } ]
           end
-        end.reduce({}, :merge)
+        end.reduce([], :<<).flatten
 
         Table.new.tap do |t|
           t.headers 'Name', 'Version'
-          latest.each do |k,v|
-            t.row bold(Paint[k, :cyan]), v.map(&:version).join(', ')
+          latest.each do |s|
+            case version_depth
+            when :all
+              t.row(
+                bold(Paint[s[:name], :cyan]),
+                s[:versions].map(&:version).join("\n")
+              )
+            else
+              t.row(
+                bold(Paint[s[:name], :cyan]),
+                s[:versions].map(&:version).join(', ')
+              )
+            end
           end
         end
       end

--- a/lib/silo/software.rb
+++ b/lib/silo/software.rb
@@ -30,9 +30,12 @@ module FlightSilo
                 s[:versions].map(&:version).join("\n")
               )
             else
+              is_more = grouped[s[:name]].length > version_depth
+              version_col = s[:versions].map(&:version).join(', ')
+              version_col << '...' if is_more
               t.row(
                 bold(Paint[s[:name], :cyan]),
-                s[:versions].map(&:version).join(', ')
+                version_col
               )
             end
           end

--- a/lib/silo/tar_utils.rb
+++ b/lib/silo/tar_utils.rb
@@ -7,8 +7,15 @@ module FlightSilo
       $?.success?
     end
 
-    def extract_tar_gz(file, dest)
-      `tar -xf #{file} -C #{File.expand_path(dest)}`
+    def extract_tar_gz(file, dest, mkdir_p: false)
+      dest = File.expand_path(dest)
+
+      unless mkdir_p
+        raise NoSuchDirectoryError, "Local directory '#{dest}' not found"
+      end
+
+      FileUtils.mkdir_p(dest)
+      `tar -xf #{file} -C #{dest}`
       $?.success?
     end
   end

--- a/lib/silo/tar_utils.rb
+++ b/lib/silo/tar_utils.rb
@@ -1,0 +1,12 @@
+require 'open3'
+
+module FlightSilo
+  module TarUtils
+    class << self
+      def valid_tar_gz?(file)
+        `tar -tzf #{file} >/dev/null`
+        $?.success?
+      end
+    end
+  end
+end

--- a/lib/silo/tar_utils.rb
+++ b/lib/silo/tar_utils.rb
@@ -6,5 +6,10 @@ module FlightSilo
       `tar -tzf #{file} >/dev/null 2>&1`
       $?.success?
     end
+
+    def extract_tar_gz(file, dest)
+      `tar -xf #{file} -C #{File.expand_path(dest)}`
+      $?.success?
+    end
   end
 end

--- a/lib/silo/tar_utils.rb
+++ b/lib/silo/tar_utils.rb
@@ -2,11 +2,9 @@ require 'open3'
 
 module FlightSilo
   module TarUtils
-    class << self
-      def valid_tar_gz?(file)
-        `tar -tzf #{file} >/dev/null`
-        $?.success?
-      end
+    def valid_tar_gz?(file)
+      `tar -tzf #{file} >/dev/null 2>&1`
+      $?.success?
     end
   end
 end

--- a/lib/silo/tar_utils.rb
+++ b/lib/silo/tar_utils.rb
@@ -15,8 +15,17 @@ module FlightSilo
       end
 
       FileUtils.mkdir_p(dest)
-      `tar -xf #{file} -C #{dest}`
-      $?.success?
+
+      stdout, stderr, status = Open3.capture3(
+        "tar -xf #{file} -C #{dest}"
+      )
+
+      return status.success? if status.success?
+      raise <<~ERROR.chomp
+
+      Error extracting tarball '#{dest}':
+      #{stderr}
+      ERROR
     end
   end
 end


### PR DESCRIPTION
This PR introduces the idea of 'software' to Flight Silo. A 'software' is a `.tar.gz` file that a user can upload to their silo with an attached name/version number. The 'software' can then be downloaded to another system with access to the silo, where it will be extracted to the directory set in the `software_dir` config key.

**Important features**

- `software push FILE NAME VERSION`
  - Name is enforced to be lowercase
  - File must have the `.tar.gz` extension; we aren't verifying that it is a valid `.tar.gz`, because that requires decompressing the archive which takes a long time for bigger archives
  - Version number must match the format accepted by `Gem::Version` (see [this gross regular expression](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/version.rb#LL158))
  - ~We aren't checking for existing versions; if you try to push a software name/version combo that exists, the existing one is overwritten (might want to change this?)~ If a software name/version combo exists, `--force` is required to overwrite it.
- `software pull NAME VERSION`
  - `.tar.gz` file is downloaded to `/tmp` before extracting it to the user's software directory
  - If the file they pushed had the `.tar.gz` extension, but wasn't a valid gzipped tarball, an error will be raised (a user would have to put in the effort to make this happen, so it's on them)
  - `software_dir` can be set in global settings (`#{root}/etc/config.yaml`), user settings ('~/.config/flight/silo/config.yml`), or overridden with env variable (`flight_SILO_software-dir`)
  - If software already exists at given path, require `--overwrite` to overwrite it
- ~`software list`~ `software search`
  - Rather than storing an index of software names/versions, a software is stored upstream as `<NAME>~<VERSION>.software`, so that we can infer the metadata from the filename
  - The printed table is sorted by software name, and then by version number (ascending)
  - Accepts an optional search term:
    - When no search term given, list 5 latest versions of all softwares
    - When search term given, list all versions of softwares with name containing search term
  - When using search term, filesizes are listed too
- `software delete NAME VERSION`
  - Delete version if it exists, nothing special about this one
- `Silo#list`
  - The expected output from a type's `list.sh` action has changed from a YAML array of filenames to a YAML array of dicts, each with key `name` and `filesize`
  - The `Silo#list` method now returns an array of hashes for `files` instead of an array of strings

- README has been updated for software functionality as well as some missed `file ____` functionality