### PR TITLE
Remove padding from list

### DIFF
--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -55,9 +55,9 @@ module FlightSilo
         dirs, files = silo.list(dir)
 
         dirs&.each do |dir|
-          puts Paint[" " + bold(dir), :blue]
+          puts Paint[bold(dir), :blue]
         end
-        puts files&.map { |f| " " + f }
+        puts files
       end
 
       def bold(string)


### PR DESCRIPTION
This small PR modifies the list command to work the same way it does in `0.0.0`, with the indentation and trailing newline removed.