### PR TITLE
Pull to STDOUT

### DIFF
--- a/etc/types/aws/actions/print_file.sh
+++ b/etc/types/aws/actions/print_file.sh
@@ -1,5 +1,0 @@
-set -e
-
-test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
-object_uri="s3://$SILO_NAME/$SILO_SOURCE"
-$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" -  $sign_request $recursive

--- a/etc/types/aws/actions/pull.sh
+++ b/etc/types/aws/actions/pull.sh
@@ -3,4 +3,5 @@ set -e
 test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
 test $SILO_RECURSIVE = "true" && recursive=--recursive || recursive=""
 object_uri="s3://$SILO_NAME/$SILO_SOURCE"
-$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" "$SILO_DEST" $sign_request $recursive
+destination=${SILO_DEST:=/dev/stdout}
+$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" "$destination" $sign_request $recursive

--- a/etc/types/aws/actions/pull.sh
+++ b/etc/types/aws/actions/pull.sh
@@ -4,4 +4,4 @@ test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
 test $SILO_RECURSIVE = "true" && recursive=--recursive || recursive=""
 object_uri="s3://$SILO_NAME/$SILO_SOURCE"
 destination=${SILO_DEST:=/dev/stdout}
-$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" "$destination" $sign_request $recursive
+$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" "$destination" $sign_request $recursive --quiet

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -68,10 +68,12 @@ module FlightSilo
       c.action Commands, :type_avail
     end
 
-    command "type prepare" do |c|
-      cli_syntax(c, 'TYPE')
-      c.description = "Prepare an available provider type for use"
-      c.action Commands, :type_prepare
+    if Process.euid == 0
+      command "type prepare" do |c|
+        cli_syntax(c, 'TYPE')
+        c.description = "Prepare an available provider type for use"
+        c.action Commands, :type_prepare
+      end
     end
 
     command 'repo add' do |c|

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -55,15 +55,13 @@ module FlightSilo
         env = {
           'SILO_NAME' => silo_id,
           'SILO_SOURCE' => 'cloud_metadata.yaml',
-          'SILO_DEST' => File.join(type.dir, 'cloud_metadata.yaml'),
+          'SILO_DEST' => nil,
           'SILO_PUBLIC' => 'false',
           'SILO_RECURSIVE' => 'false'
         }.merge(creds)
 
-        type.run_action('pull.sh', env: env)
+        cloud_md = YAML.load(type.run_action('pull.sh', env: env))
 
-        cloud_md = YAML.load_file("#{type.dir}/cloud_metadata.yaml")
-        `rm "#{type.dir}/cloud_metadata.yaml"`
         `mkdir -p #{Config.user_silos_path}`
         md = answers.merge(cloud_md).merge({"id" => silo_id})
         File.open("#{Config.user_silos_path}/#{silo_id}.yaml", "w") { |file| file.write(md.to_yaml) }

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -211,17 +211,6 @@ module FlightSilo
       ]
     end
 
-    def print_file(file)
-      self.class.check_prepared(@type)
-      env = {
-        'SILO_NAME' => @id,
-        'SILO_SOURCE' => file,
-        'SILO_PUBLIC' => @is_public.to_s
-      }.merge(@creds)
-
-      run_action('print_file.sh', env: env).chomp
-    end
-
     def pull(source, dest, recursive: false)
       self.class.check_prepared(@type)
       env = {

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -55,7 +55,6 @@ module FlightSilo
         env = {
           'SILO_NAME' => silo_id,
           'SILO_SOURCE' => 'cloud_metadata.yaml',
-          'SILO_DEST' => nil,
           'SILO_PUBLIC' => 'false',
           'SILO_RECURSIVE' => 'false'
         }.merge(creds)


### PR DESCRIPTION
This PR modifies the `pull` action to return file contents to `stdout` if the `SILO_DEST` variable is not set. This makes adding silos less cumbersome, and fixes permission issues seen when running Silo without root user privileges. The equivalent action `print_file` is removed since these changes make it obsolete.