### PR TITLE
Add OpenStack silo type

### DIFF
--- a/etc/types/openstack/actions/create.sh
+++ b/etc/types/openstack/actions/create.sh
@@ -1,0 +1,10 @@
+set -e
+
+bucket=$SILO_ID
+$SILO_TYPE_DIR/cli/bin/aws s3 mb s3://$bucket --region '' # the CLI insists that you give it a region, even though OpenStack doesn't really care about regions
+$SILO_TYPE_DIR/cli/bin/aws s3api put-object --bucket $bucket --key files/
+$SILO_TYPE_DIR/cli/bin/aws s3api put-object --bucket $bucket --key projects/
+$SILO_TYPE_DIR/cli/bin/aws s3api put-object --bucket $bucket --key software/
+printf -- "---\nname: $SILO_NAME\ndescription:\nis_public: false\n" > "/tmp/${SILO_ID}_cloud_md.yaml"
+$SILO_TYPE_DIR/cli/bin/aws s3api put-object --bucket $bucket --key cloud_metadata.yaml --body "/tmp/${SILO_ID}_cloud_md.yaml"
+rm -f "/tmp/${SILO_ID}_cloud_md.yaml"

--- a/etc/types/openstack/actions/delete.sh
+++ b/etc/types/openstack/actions/delete.sh
@@ -1,0 +1,4 @@
+test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
+test $SILO_RECURSIVE = "true" && recursive=--recursive || recursive=""
+object_uri="s3://$SILO_NAME/$SILO_PATH"
+$SILO_TYPE_DIR/cli/bin/aws s3 rm "$object_uri" $sign_request $recursive

--- a/etc/types/openstack/actions/delete_silo_upstream.sh
+++ b/etc/types/openstack/actions/delete_silo_upstream.sh
@@ -1,0 +1,4 @@
+set -e
+
+bucket=$SILO_NAME
+$SILO_TYPE_DIR/cli/bin/aws s3 rb s3://$bucket --force

--- a/etc/types/openstack/actions/dir_exists.sh
+++ b/etc/types/openstack/actions/dir_exists.sh
@@ -1,0 +1,8 @@
+test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
+list=$($SILO_TYPE_DIR/cli/bin/aws s3 ls s3://$SILO_NAME/$SILO_PATH $sign_request)
+
+if [ -z "$list" ]; then
+  echo "no"
+else
+  echo "yes"
+fi

--- a/etc/types/openstack/actions/file_exists.sh
+++ b/etc/types/openstack/actions/file_exists.sh
@@ -1,0 +1,8 @@
+test $SILO_PUBLIC = true && sign_request=--no-sign-request || sign_request=""
+not_exist=$($SILO_TYPE_DIR/cli/bin/aws s3api head-object --bucket "$SILO_NAME" --key "$SILO_PATH" $sign_request --output json >/dev/null 2>&1; echo $?)
+
+if [ $not_exist != 0 ]; then
+  echo "no"
+else
+  echo "yes"
+fi

--- a/etc/types/openstack/actions/get_silo.sh
+++ b/etc/types/openstack/actions/get_silo.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+data=$($SILO_TYPE_DIR/cli/bin/aws s3api list-buckets --output json)
+buckets=($(echo $data |
+  sed -e 's/[{}]/''/g' |
+    awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' |
+      sed -n -e 's/^.*Name": //p' |
+        grep flight-silo- |
+          cut -d'"' -f2))
+
+for bucket in ${buckets[@]}; do
+  can_access=$($SILO_TYPE_DIR/cli/bin/aws s3api head-bucket --bucket $bucket >/dev/null 2>&1; echo $?)
+  if [ $can_access == 0 ]; then
+    metadata=$($SILO_TYPE_DIR/cli/bin/aws s3 cp s3://$bucket/cloud_metadata.yaml -)
+    name=$(echo "$metadata" | grep name: | awk '{print $2}' | cut -d'"' -f2)
+    if [ $name == $SILO_NAME ]; then
+      echo $bucket
+      exit 0
+    fi
+  fi
+done

--- a/etc/types/openstack/actions/list.sh
+++ b/etc/types/openstack/actions/list.sh
@@ -1,0 +1,21 @@
+test $SILO_PUBLIC = true && sign_request=--no-sign-request || sign_request=""
+
+files=$($SILO_TYPE_DIR/cli/bin/aws s3api list-objects-v2 --bucket "$SILO_NAME" --prefix "$SILO_PATH" --delimiter / --output json --query "Contents[?!(Key=='$SILO_PATH')].{ name: Key, size: Size}" $sign_request)
+
+directories=$($SILO_TYPE_DIR/cli/bin/aws s3api list-objects-v2 --bucket "$SILO_NAME" --prefix "$SILO_PATH" --delimiter / --output json --query CommonPrefixes[:].Prefix $sign_request)
+
+if [[ "$files" == "null" ]] ; then
+  FILES=[]
+else
+  FILES=$files
+fi
+
+if [[ "$directories" == "null" ]] ; then
+  DIRECTORIES=[]
+else
+  DIRECTORIES=$directories
+fi
+
+cat << EOF
+{"files":$FILES,"directories":$DIRECTORIES}
+EOF

--- a/etc/types/openstack/actions/pull.sh
+++ b/etc/types/openstack/actions/pull.sh
@@ -1,0 +1,7 @@
+set -e
+
+test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
+test $SILO_RECURSIVE = "true" && recursive=--recursive || recursive=""
+object_uri="s3://$SILO_NAME/$SILO_SOURCE"
+destination=${SILO_DEST:=/dev/stdout}
+$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" "$destination" $sign_request $recursive --quiet

--- a/etc/types/openstack/actions/push.sh
+++ b/etc/types/openstack/actions/push.sh
@@ -1,0 +1,34 @@
+OBJECT_URI="s3://$SILO_NAME/$SILO_DEST"
+
+if $SILO_RECURSIVE ; then
+  $SILO_TYPE_DIR/cli/bin/aws s3 cp $SILO_SOURCE $OBJECT_URI --recursive
+
+  FILES=$(find "$SILO_SOURCE" -type d)
+  while IFS= read -r line; do
+    KEY=$(realpath --relative-to="$SILO_SOURCE/.." $line)
+
+    KEY=${KEY#"$(basename $SILO_SOURCE)"}
+    if [[ "$SILO_DEST" == */ ]] ; then
+      SILO_DEST=${SILO_DEST%?}
+    fi
+
+    $SILO_TYPE_DIR/cli/bin/aws s3api put-object --bucket $SILO_NAME --key "$SILO_DEST$KEY/"
+  done <<< "$FILES"
+else
+  IFS='/' read -ra ADDR <<< ${SILO_DEST}
+
+  KEY=''
+  for i in "${ADDR[@]}"; do
+    if [ "$i" == "${ADDR[0]}" ] || [ "$i" == "${ADDR[-1]}" ] || [ -z  "$i" ]; then
+      continue
+    fi
+
+    KEY+="$i/"
+    NEWKEY=${KEY#"$(basename $SILO_SOURCE)"}
+    NEWKEY="${ADDR[0]}/$NEWKEY"
+
+    $SILO_TYPE_DIR/cli/bin/aws s3api put-object --bucket $SILO_NAME --key "$NEWKEY"
+  done
+
+  $SILO_TYPE_DIR/cli/bin/aws s3 cp $SILO_SOURCE $OBJECT_URI
+fi

--- a/etc/types/openstack/metadata.yaml
+++ b/etc/types/openstack/metadata.yaml
@@ -1,0 +1,24 @@
+---
+:name: openstack
+:description: Openstack Swift Storage
+:questions:
+  :metadata:
+    - :id: AWS_ENDPOINT_URL
+      :text: 'Endpoint URL:'
+      :validation:
+        :type: string
+    - :id: name
+      :text: 'Silo name:'
+      :validation:
+        :type: string
+        :format: "^[a-zA-Z0-9_\\-]+$"
+        :message: 'Invalid silo name: %{value}. Must contain only alphanumeric characters, - and _'
+  :credentials:
+    - :id: AWS_ACCESS_KEY_ID
+      :text: 'Access key ID:'
+      :validation:
+        :type: string
+    - :id: AWS_SECRET_ACCESS_KEY
+      :text: 'Secret access key:'
+      :validation:
+        :type: string

--- a/etc/types/openstack/prepare.sh
+++ b/etc/types/openstack/prepare.sh
@@ -1,6 +1,6 @@
 set -e
 
-TYPE_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null & pwd )
+TYPE_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 mkdir -p $TYPE_DIR/cli/bin
 

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -83,7 +83,7 @@ module FlightSilo
 
         extract_tar_gz(tmp_path, extract_path, mkdir_p: true)
 
-        puts "Extracted software '#{name}' version '#{version} to '#{Config.user_software_dir}'..."
+        puts "Extracted software '#{name}' version '#{version}' to '#{Config.user_software_dir}'..."
       ensure
         FileUtils.rm(tmp_path) if File.file?(tmp_path)
       end


### PR DESCRIPTION
This PR introduces OpenStack support to Flight Silo. Silos existing on an OpenStack Object Storage instance can now be created/added and used.

Much of the work here is copied from the AWS action scripts. OpenStack's `Swift3` middleware emulates the S3 REST API on top of Object Storage, so we are able to interact with it in the same way that we would the genuine S3 REST API. Few operations are supported (see: https://docs.openstack.org/mitaka/config-reference/object-storage/configure-s3.html), but it supports everything that Silo needs access to.

The main addition to get it working seamlessly is the `endpoint_url` metadata key when setting up an OpenStack silo. The AWS CLI supports setting the endpoint used for service requests (see: https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html). When setting up an OpenStack silo, one must provide the Object Store API URL. The endpoint URL is then set as an env var for all OpenStack actions, the same way that the user credentials are set.

There is also a small workaround in the `create` action for OpenStack. The CLI insists on being given a `region` with the `make-bucket` endpoint, but OpenStack doesn't really have regions, so we give it an empty string to keep it happy.