### PR TITLE
Enh/file name validation

### DIFF
--- a/etc/types/aws/prepare.sh
+++ b/etc/types/aws/prepare.sh
@@ -1,15 +1,13 @@
 set -e
 
-TYPE_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null & pwd )
-
-mkdir -p $TYPE_DIR/cli/bin
+mkdir -p $flight_SILO_types/aws/cli/bin
 
 temp_dir=$(mktemp -d)
 cd $temp_dir
 
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" -s
 unzip -qq awscliv2.zip
-./aws/install -i $TYPE_DIR/cli/aws_cli -b $TYPE_DIR/cli/bin
+./aws/install -i $flight_SILO_types/aws/cli/bin/cli/aws_cli -b $flight_SILO_types/aws/cli/bin/
 rm -rf $temp_dir
 
 echo "Prepared"

--- a/lib/silo/commands/file_push.rb
+++ b/lib/silo/commands/file_push.rb
@@ -40,12 +40,13 @@ module FlightSilo
 
         source = args[0]
 
+        raise InvalidFileNameError, "Target destination '#{args[1]}' contains invalid symbol" unless args[1].nil? || args[1].match?(/^[^:]+(:[^:]+)?$/)
+        
         # standardize args[1] to [silo_name, dest]
-        split_args = args[1]&.split(":", 2).map(&:to_s) || ['']
+        split_args = args[1]&.split(":", 2)&.map(&:to_s) || ['']
         split_args.unshift(Silo.default) if split_args.size == 1
         
         silo_name, dest = split_args
-        raise InvalidFileNameError, "Target destination '#{dest}' contains invalid symbol" if dest.match(/[: ]/)
 
         silo = Silo[silo_name]
         raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo

--- a/lib/silo/commands/file_push.rb
+++ b/lib/silo/commands/file_push.rb
@@ -59,6 +59,8 @@ module FlightSilo
         if @options.recursive
           if !File.directory?(source)
             raise NoSuchDirectoryError, "Local directory '#{source}' not found"
+          else
+            traverse_validation(source)
           end
 
           if move_contents
@@ -92,6 +94,19 @@ module FlightSilo
 
         silo.push(source, target, recursive: @options.recursive)
         puts out
+      end
+
+      def traverse_validation(directory)
+        raise InvalidFileNameError, "Source file or directory '#{directory}' contains invalid symbol" if directory.match?(/[: ]/)
+        Dir.foreach(directory) do |item|
+          next if item == '.' || item == '..'
+          item_path = File.join(directory, item)
+          raise InvalidFileNameError, "Source file or directory '#{item_path}' contains invalid symbol" if item.match?(/[: ]/)
+          
+          if File.directory?(item_path)
+            traverse_validation(item_path)
+          end
+        end
       end
     end
   end

--- a/lib/silo/commands/file_push.rb
+++ b/lib/silo/commands/file_push.rb
@@ -40,7 +40,7 @@ module FlightSilo
 
         source = args[0]
 
-        raise InvalidFileNameError, "Target destination '#{args[1]}' contains invalid symbol" unless args[1].nil? || args[1].match?(/^[^:]+(:[^:]+)?$/)
+        raise InvalidFileNameError, "Target destination '#{args[1]}' contains invalid symbol" unless args[1].nil? || args[1].match?(/^[^:]+:?[^:]*$/)
         
         # standardize args[1] to [silo_name, dest]
         split_args = args[1]&.split(":", 2)&.map(&:to_s) || ['']

--- a/lib/silo/commands/file_push.rb
+++ b/lib/silo/commands/file_push.rb
@@ -40,14 +40,12 @@ module FlightSilo
 
         source = args[0]
 
-        if args[1]&.match(/^[^:]*:[^:]*$/)
-          silo_name, dest = args[1].split(":").map(&:to_s)
-        else
-          silo_name = Silo.default
-          dest = args[1] || ''
-        end
-
-        dest ||= ''
+        # standardize args[1] to [silo_name, dest]
+        split_args = args[1]&.split(":", 2).map(&:to_s) || ['']
+        split_args.unshift(Silo.default) if split_args.size == 1
+        
+        silo_name, dest = split_args
+        raise InvalidFileNameError, "Target destination '#{dest}' contains invalid symbol" if dest.match(/[: ]/)
 
         silo = Silo[silo_name]
         raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo

--- a/lib/silo/commands/file_push.rb
+++ b/lib/silo/commands/file_push.rb
@@ -79,6 +79,7 @@ module FlightSilo
           end
 
           if dest.empty? || dest[-1] =='/'
+            raise InvalidFileNameError, "Source file or directory '#{source}' contains invalid symbol" if source.match?(/[: ]/)
             target = File.join('files', dest.squeeze('/'), File.basename(source))
           else
             target = File.join('files', dest.squeeze('/'))

--- a/lib/silo/errors.rb
+++ b/lib/silo/errors.rb
@@ -32,4 +32,5 @@ module FlightSilo
   NoSuchSiloError = Class.new(RuntimeError)
   NoSuchDirectoryError = Class.new(RuntimeError)
   NoSuchFileError = Class.new(RuntimeError)
+  InvalidFileNameError = Class.new(RuntimeError)
 end


### PR DESCRIPTION
# Overview

Based on the current `silo file` syntax, the colon in the filename makes it difficult to distinguish whether the content before the colon is a silo name or part of the file name. To solve this problem, colon and space are no longer allowed to be included in a filename, which will be validated during `silo file push` operation.

# Major Changes

- Modified the algorithm in `FilePush#run` to correctly parse the silo name and destination argument and validate the destination
- A corresponding `InvalidFileNameError` is defined in errors.rb