### PR TITLE
Software Pull Directory Cli Argument Config Support

### DIFF
--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -154,6 +154,7 @@ module FlightSilo
       c.description = "Pull a software binary from a silo to your apps directory"
       c.slop.string '--repo', 'Override default silo'
       c.slop.boolean '--overwrite', 'Overwrite software locally if it exists'
+      c.slop.string '--dir', 'Overwrite the software directory configuration'
       c.action Commands, :software_pull
     end
 

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -59,8 +59,9 @@ module FlightSilo
           raise "Software '#{name}' version '#{version}' not found"
         end
 
+        software_dir = @options.dir || Config.user_software_dir
         extract_path = File.join(
-          Config.user_software_dir,
+          software_dir,
           name,
           version
         )
@@ -79,11 +80,11 @@ module FlightSilo
         silo.pull(software_path, tmp_path)
 
         # Extract software to software dir
-        puts "Extracting software to '#{Config.user_software_dir}'..."
+        puts "Extracting software to '#{software_dir}'..."
 
         extract_tar_gz(tmp_path, extract_path, mkdir_p: true)
 
-        puts "Extracted software '#{name}' version '#{version}' to '#{Config.user_software_dir}'..."
+        puts "Extracted software '#{name}' version '#{version}' to '#{software_dir}'..."
       ensure
         FileUtils.rm(tmp_path) if File.file?(tmp_path)
       end


### PR DESCRIPTION
# Overview

This PR adds the `--dir` option to `silo software pull` command as a supplement to the software decompression path configuration approaches. This option should have higher priority than all the previous configuration methods.

# Major Changes

- The `--dir` slop is added to `cli.rb` as a new option of the `software pull` command.
- The implementation of the pull logic is changed to read the `--dir` option.
- The output text is updated to reflect the correct path.

# Testing

1. Launch a Flight Solo instance.
2. Overwrite the integrated Flight Silo located at `/opt/flight/opt/silo` with the content of this branch.
3. run the following command as the preparation:
   ```
   flight silo set-default openflight
   ```
3. run the following command to check the description of the `--dir` option:
   ```
   flight silo software pull --help
   ```
4. run the following command:
   ```
   flight_SILO_software_dir="~/env-dir" flight silo software pull hadoop 3.2.1 --dir "~/cli-dir"
   ```
   As can be seen from the above command, both environment variable and `--dir` option are used. In this case, the software should be extracted to the `~/cli-dir` path.
5. run the following command:
   ```
   flight_SILO_software_dir="~/env-dir" flight silo software pull hadoop 3.2.1
   ```
   This time, the software should be extracted to the `~/env-dir` path since the `--dir` option was not provided.
6. run the following command:
   ```
   flight silo software pull hadoop 3.2.1
   ```
   The software should be extracted to the path that was defined in `/opt/flight/opt/silo/etc/config.yml`, which could be `~/app`.
7. Run `vim /opt/flight/opt/silo/etc/config.yml` and remove the `software_dir` configuration. Then, run the following command:
   ```
   flight silo software pull hadoop 3.2.1
   ```
   The software should be extracted to the default path, which could be `~/.local/share/flight/silo/software`.