### PR TITLE
File List Output Optimiztion

### DIFF
--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -72,7 +72,7 @@ module FlightSilo
             print_width += column_width
             {
               'width' => column_width,
-              'items' => column_items
+              'items' => cis
             }
           end
           break if print_width <= screen_width

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -55,8 +55,8 @@ module FlightSilo
         data = silo.list(dir)
         dirs, files = data['directories'], data['files']
 
-        dirs.map! { |d| { 'type' => 'd', 'name' = d } }
-        files.map! { |f| { 'type' => 'f', 'name' = f[:name] } }
+        dirs.map! { |d| { 'type' => 'd', 'name' => d } }
+        files.map! { |f| { 'type' => 'f', 'name' => f[:name] } }
         list = dirs.concat(files).sort_by { |i| i['name'] }
         number_of_items = list.size
         screen_width = IO.console.winsize[1]

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -85,9 +85,9 @@ module FlightSilo
             column_width = cis['width']
             if cis['items'][i]
               type = cis['items'][i]['type']
-              name = type == 'd' ? Paint[bold(cis['items'][i]['name']), :blue] : cis['items'][i]['name']
+              name = cis['items'][i]['name']
               name += " " * (column_width - name.length)
-              output_row += name  
+              output_row += type == 'd' ? Paint[bold(name), :blue] : name
             end
           end
           puts output_row

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -57,7 +57,7 @@ module FlightSilo
 
         dirs.map! { |d| { 'type' => 'd', 'name' => d } }
         files.map! { |f| { 'type' => 'f', 'name' => f[:name] } }
-        list = dirs.concat(files).sort_by { |i| i['name'] }
+        list = dirs.concat(files).sort_by { |i| i['name'].downcase }
         number_of_items = list.size
         screen_width = IO.console.winsize[1]
         number_of_rows = 1

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -58,7 +58,6 @@ module FlightSilo
         dirs.map! { |d| { 'type' => 'd', 'name' => d } }
         files.map! { |f| { 'type' => 'f', 'name' => f[:name] } }
         list = dirs.concat(files).sort_by { |i| i['name'].downcase }
-        number_of_items = list.size
         screen_width = IO.console.winsize[1]
         number_of_rows = 1
 
@@ -83,12 +82,11 @@ module FlightSilo
           output_row = ""
           column_items.each do |cis|
             column_width = cis['width']
-            if cis['items'][i]
-              type = cis['items'][i]['type']
-              name = cis['items'][i]['name']
-              name += " " * (column_width - name.length)
-              output_row += type == 'd' ? Paint[bold(name), :blue] : name
-            end
+            next unless cis['items'][i]
+            type = cis['items'][i]['type']
+            name = cis['items'][i]['name']
+            name += " " * (column_width - name.length)
+            output_row += type == 'd' ? Paint[bold(name), :blue] : name
           end
           puts output_row
         end

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -83,10 +83,12 @@ module FlightSilo
           output_row = ""
           column_items.each do |cis|
             column_width = cis['width']
-            type = cis['items'][i]['type']
-            name = type == 'd' ? Paint[bold(cis['items'][i]['name']), :blue] : cis['items'][i]['name']
-            name += " " * (column_width - name.length)
-            output_row += name
+            if cis['items'][i]
+              type = cis['items'][i]['type']
+              name = type == 'd' ? Paint[bold(cis['items'][i]['name']), :blue] : cis['items'][i]['name']
+              name += " " * (column_width - name.length)
+              output_row += name  
+            end
           end
           puts output_row
         end

--- a/lib/silo/commands/file_list.rb
+++ b/lib/silo/commands/file_list.rb
@@ -92,11 +92,6 @@ module FlightSilo
           end
           puts output_row
         end
-
-        # dirs&.each do |dir|
-        #   puts Paint[bold(dir), :blue]
-        # end
-        # puts files.map { |f| f[:name] } if files
       end
 
       def bold(string)


### PR DESCRIPTION
# Overview

This PR changes the output of `flight silo file list` to a format that consistent with the system `ls` command.

# Major Changes

- The new output logic is added to `file_list.rb`.

# Testing

1. Create a new flight solo instance and run the following commands:
   ```
   git clone https://github.com/openflighthpc/flight-silo.git && cd flight-silo
   git checkout enh/file-list-format
   unalias cp
   cp -rf ./* /opt/flight/opt/silo
   ``` 
2. Create or add a silo repository and upload files to it.
3. run `flight silo file list <repo>:<dir>` to view the output. Change the width of the console window and test the output again.