### PR TITLE
Introduce `repo edit` and `repo refresh` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ prepare any required types.
 `repo create` will create a silo for your chosen provider. You can then add
 your silo to other systems using the same credentials.
 
+`repo edit` may be used to change the name or description of a silo. This updates
+both the upstream and local silo data. If the name of the default silo is changed, 
+that will also be updated.
+
+`repo refresh` will update local silo metadata to match upstream data. A mismatch
+could be created through use of `repo edit` on a different machine.
+
 `repo remove` will remove the silo metadata from your system, while
 `repo delete` will destroy the upstream silo (requiring confirmation to do so).
 

--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -11,3 +11,6 @@
 #
 # Directory to extract softwares to
 #software_dir: ~/.local/share/flight/silo/software/
+#
+# If true, silo metadata will be refreshed automatically without requiring a manual refresh
+#force_refresh: false

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -100,6 +100,12 @@ module FlightSilo
       c.action Commands, :repo_edit
     end
 
+    command 'repo refresh' do |c|
+      cli_syntax(c, 'REPO')
+      c.description = "Update local silo information to match upstream changes"
+      c.action Commands, :repo_refresh
+    end
+
     command 'repo remove' do |c|
       cli_syntax(c, 'REPO')
       c.description = "Remove an existing silo from your system"

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -95,13 +95,13 @@ module FlightSilo
     end
 
     command 'repo edit' do |c|
-      cli_syntax(c, 'REPO')
+      cli_syntax(c, '[REPO]')
       c.description = "Edit the name and/or description of an existing silo"
       c.action Commands, :repo_edit
     end
 
     command 'repo refresh' do |c|
-      cli_syntax(c, 'REPO')
+      cli_syntax(c, '[REPO]')
       c.description = "Update local silo information to match upstream changes"
       c.action Commands, :repo_refresh
     end

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -94,6 +94,12 @@ module FlightSilo
       c.action Commands, :repo_delete
     end
 
+    command 'repo edit' do |c|
+      cli_syntax(c, 'REPO')
+      c.description = "Edit the name and/or description of an existing silo"
+      c.action Commands, :repo_edit
+    end
+
     command 'repo remove' do |c|
       cli_syntax(c, 'REPO')
       c.description = "Remove an existing silo from your system"

--- a/lib/silo/commands/repo_create.rb
+++ b/lib/silo/commands/repo_create.rb
@@ -36,6 +36,8 @@ module FlightSilo
         type_name = prompt.select("Provider type:", types)
         type = Type[type_name]
 
+        Silo.check_prepared(type)
+
         questions = type.questions
 
         metadata = ask_questions(questions[:metadata])

--- a/lib/silo/commands/repo_edit.rb
+++ b/lib/silo/commands/repo_edit.rb
@@ -35,7 +35,8 @@ module FlightSilo
   module Commands
     class RepoEdit < Command
       def run
-        raise "Silo '#{@args[0]}' not found" unless silo = Silo[@args[0]]
+        silo_name = args[0] || Silo.default
+        raise "Silo '#{silo_name}' not found" unless silo = Silo[silo_name]
         raise "Cannot edit public silos" if silo.is_public
 
         prompt = TTY::Prompt.new(help_color: :yellow)
@@ -55,11 +56,7 @@ module FlightSilo
         end
         puts "Updating silo details..."
 
-        old_name = silo.name
         silo.set_metadata(answers.merge({"is_public" => false}))
-        if old_name == Silo.default
-          Silo.set_default(silo.name)
-        end
 
         puts "Silo details updated"
       end

--- a/lib/silo/commands/repo_edit.rb
+++ b/lib/silo/commands/repo_edit.rb
@@ -54,9 +54,13 @@ module FlightSilo
           end
         end
         puts "Updating silo details..."
-        File.write('/tmp/#{silo.id}_cloud_metadata.yaml', answers.to_yaml)
-        silo.push('/tmp/#{silo.id}_cloud_metadata.yaml', 'cloud_metadata.yaml')
-        File.delete('/tmp/#{silo.id}_cloud_metadata.yaml')
+
+        old_name = silo.name
+        silo.set_metadata(answers.merge({"is_public" => false}))
+        if old_name == Silo.default
+          Silo.set_default(silo.name)
+        end
+
         puts "Silo details updated"
       end
     end

--- a/lib/silo/commands/repo_edit.rb
+++ b/lib/silo/commands/repo_edit.rb
@@ -51,7 +51,6 @@ module FlightSilo
           key('description').ask("Silo description:") do |q|
             q.default silo.description
             q.required false
-            q.messages[:valid?] = 'Invalid silo name: %{value}. Must contain only alphanumeric characters, - and _'
           end
         end
         puts "Updating silo details..."

--- a/lib/silo/commands/repo_edit.rb
+++ b/lib/silo/commands/repo_edit.rb
@@ -24,47 +24,30 @@
 # For more information on Flight Silo, please visit:
 # https://github.com/openflighthpc/flight-silo
 #==============================================================================
-require_relative 'commands/type_avail'
-require_relative 'commands/type_prepare'
-require_relative 'commands/repo_add'
-require_relative 'commands/repo_create'
-require_relative 'commands/repo_delete'
-require_relative 'commands/repo_edit'
-require_relative 'commands/repo_remove'
-require_relative 'commands/repo_list'
-require_relative 'commands/file_delete'
-require_relative 'commands/file_list'
-require_relative 'commands/file_pull'
-require_relative 'commands/file_push'
-require_relative 'commands/software_delete'
-require_relative 'commands/software_pull'
-require_relative 'commands/software_push'
-require_relative 'commands/software_search'
-require_relative 'commands/set_default'
+require_relative '../command'
+require_relative '../silo'
+require_relative '../type'
+
+require 'yaml'
+require 'tty-prompt'
 
 module FlightSilo
   module Commands
-    class << self
-      def method_missing(s, *a, &b)
-        if clazz = to_class(s)
-          clazz.new(*a).run!
-        else
-          raise 'command not defined'
-        end
-      end
+    class RepoEdit < Command
+      def run
+        raise "Silo '#{@args[0]}' not found" unless silo = Silo[@args[0]]
+        raise "Cannot delete public silos" if silo.is_public
 
-      def respond_to_missing?(s)
-        !!to_class(s)
-      end
+        prompt = TTY::Prompt.new(help_color: :yellow)
 
-      private
-      def to_class(s)
-        s.to_s.split('-').reduce(self) do |clazz, p|
-          p.gsub!(/_(.)/) {|a| a[1].upcase}
-          clazz.const_get(p[0].upcase + p[1..-1])
+        prompt.collect do
+          key(:name).ask("Silo name:") do |q|
+            q.default silo.name
+            q.required true
+            q.validate Regexp.new("^[a-zA-Z0-9_\\-]+$")
+            q.messages[:valid?] = 'Invalid silo name: %{value}. Must contain only alphanumeric characters, - and _'
+          end
         end
-      rescue NameError
-        nil
       end
     end
   end

--- a/lib/silo/commands/repo_refresh.rb
+++ b/lib/silo/commands/repo_refresh.rb
@@ -36,7 +36,7 @@ module FlightSilo
     class RepoRefresh < Command
       def run
         silo_name = args[0] || Silo.default
-        raise "Silo '#{silo_name}' not found" unless silo = Silo[silo_name]
+        raise "Silo '#{silo_name}' not found" unless silo = Silo[silo_name, refresh: false]
         puts "Refreshing silo details..."
         if silo.refresh(forced: true)
           puts "Silo details updated:"

--- a/lib/silo/commands/repo_refresh.rb
+++ b/lib/silo/commands/repo_refresh.rb
@@ -35,7 +35,8 @@ module FlightSilo
   module Commands
     class RepoRefresh < Command
       def run
-        raise "Silo '#{@args[0]}' not found" unless silo = Silo[@args[0]]
+        silo_name = args[0] || Silo.default
+        raise "Silo '#{silo_name}' not found" unless silo = Silo[silo_name]
         puts "Refreshing silo details..."
         if silo.refresh(forced: true)
           puts "Silo details updated:"

--- a/lib/silo/commands/set_default.rb
+++ b/lib/silo/commands/set_default.rb
@@ -36,6 +36,7 @@ module FlightSilo
           puts Silo.default
         else
           # Set new default
+          raise "Silo '#{silo_name}' not found" unless silo = Silo[silo_name, refresh: false]
           Silo.set_default(args.first)
           puts "Default silo set to: #{args.first}"
         end

--- a/lib/silo/commands/set_default.rb
+++ b/lib/silo/commands/set_default.rb
@@ -36,7 +36,7 @@ module FlightSilo
           puts Silo.default
         else
           # Set new default
-          raise "Silo '#{silo_name}' not found" unless silo = Silo[silo_name, refresh: false]
+          raise "Silo '#{args.first}' not found" unless silo = Silo[args.first, refresh: false]
           Silo.set_default(args.first)
           puts "Default silo set to: #{args.first}"
         end

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -43,8 +43,6 @@ module FlightSilo
 
         name, version = args
 
-        raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
-
         software_path = File.join(
           'software',
           "#{name}~#{version}.software"
@@ -54,6 +52,8 @@ module FlightSilo
           '/tmp',
           "#{name}~#{version}~#{random_string}"
         )
+
+        raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
 
         unless silo.find_software(name, version)
           raise "Software '#{name}' version '#{version}' not found"

--- a/lib/silo/config.rb
+++ b/lib/silo/config.rb
@@ -135,6 +135,10 @@ module FlightSilo
             )
       end
 
+      def force_refresh
+        data.fetch(:force_refresh, default: false)
+      end
+
       private
 
       def xdg_config

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -255,7 +255,7 @@ module FlightSilo
       env = {
         'SILO_NAME' => id,
         'SILO_SOURCE' => 'cloud_metadata.yaml',
-        'SILO_PUBLIC' => '@is_public.to_s',
+        'SILO_PUBLIC' => @is_public.to_s,
         'SILO_RECURSIVE' => 'false'
       }.merge(creds)
 

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -252,6 +252,7 @@ module FlightSilo
     end
 
     def refresh(forced: false)
+      self.class.check_prepared(@type)
       env = {
         'SILO_NAME' => id,
         'SILO_SOURCE' => 'cloud_metadata.yaml',

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -244,9 +244,9 @@ module FlightSilo
       if @name != data["name"] && !self.class.get_silo(name: data["name"], type: @type, creds: @creds)&.empty?
         raise RemoteSiloExistsError, "A silo named '#{name}' already exists on remote provider '#{type.name}'"
       end
-      File.write('/tmp/#{silo.id}_cloud_metadata.yaml', data.to_yaml)
-      push('/tmp/#{silo.id}_cloud_metadata.yaml', 'cloud_metadata.yaml')
-      File.delete('/tmp/#{silo.id}_cloud_metadata.yaml')
+      File.write("/tmp/#{silo.id}_cloud_metadata.yaml", data.to_yaml)
+      push("/tmp/#{silo.id}_cloud_metadata.yaml", 'cloud_metadata.yaml')
+      File.delete("/tmp/#{silo.id}_cloud_metadata.yaml")
       refresh(forced: true)
       @name = data["name"]
       @description = data["description"]

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -242,7 +242,15 @@ module FlightSilo
 
       run_action('push.sh', env: env)
     end
-    
+
+    def set_metadata(data)
+      File.write('/tmp/#{silo.id}_cloud_metadata.yaml', data.to_yaml)
+      push('/tmp/#{silo.id}_cloud_metadata.yaml', 'cloud_metadata.yaml')
+      File.delete('/tmp/#{silo.id}_cloud_metadata.yaml')
+      @name = data["name"]
+      @description = data["description"]
+    end
+
     def refresh(forced: false)
       env = {
         'SILO_NAME' => id,
@@ -261,11 +269,12 @@ module FlightSilo
           md["description"] = cloud_md["description"]
           @description = cloud_md["description"]
           File.write("#{Config.user_silos_path}/#{id}.yaml", md.to_yaml)
-
-          puts "Silo details for '#{id} (#{name})' to reflect upstream changes"
+          true
         else
           raise "Local silo details do not match upstream data. Run 'repo refresh' to update local details."
         end
+      else
+        false
       end
     end
 

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -9,9 +9,9 @@ module FlightSilo
         @all ||= user_silos + global_silos + public_silos
       end
 
-      def [](name)
+      def [](name, refresh: true)
         silo = all.find { |s| s.name == name }
-        silo.refresh if silo
+        silo.refresh if silo && refresh
         silo
       end
 
@@ -247,6 +247,7 @@ module FlightSilo
       File.write('/tmp/#{silo.id}_cloud_metadata.yaml', data.to_yaml)
       push('/tmp/#{silo.id}_cloud_metadata.yaml', 'cloud_metadata.yaml')
       File.delete('/tmp/#{silo.id}_cloud_metadata.yaml')
+      refresh(forced: true)
       @name = data["name"]
       @description = data["description"]
     end

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -265,6 +265,7 @@ module FlightSilo
         if forced || Config.force_refresh
           md = YAML.load(File.read("#{Config.user_silos_path}/#{id}.yaml"))
           md["name"] = cloud_md["name"]
+          Silo.set_default(cloud_md["name"]) if @name == Config.user_data.fetch(:default_silo)
           @name = cloud_md["name"]
           md["description"] = cloud_md["description"]
           @description = cloud_md["description"]

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -11,9 +11,8 @@ module FlightSilo
 
       def [](name)
         silo = all.find { |s| s.name == name }
-
-        (silo || fetch(name))
         silo.refresh if silo
+        silo
       end
 
       def create(creds:, global: false)
@@ -106,10 +105,6 @@ module FlightSilo
       end
 
       private
-
-      def fetch(key)
-        all.find { |s| s.to_s == key }
-      end
 
       def public_silos
         @public_silos ||= silos_for(Config.public_silos_path)

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -255,7 +255,7 @@ module FlightSilo
       env = {
         'SILO_NAME' => id,
         'SILO_SOURCE' => 'cloud_metadata.yaml',
-        'SILO_PUBLIC' => 'false',
+        'SILO_PUBLIC' => '@silo.is_public',
         'SILO_RECURSIVE' => 'false'
       }.merge(creds)
 

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -255,7 +255,7 @@ module FlightSilo
       env = {
         'SILO_NAME' => id,
         'SILO_SOURCE' => 'cloud_metadata.yaml',
-        'SILO_PUBLIC' => '@silo.is_public',
+        'SILO_PUBLIC' => '@is_public.to_s',
         'SILO_RECURSIVE' => 'false'
       }.merge(creds)
 

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -92,12 +92,8 @@ module FlightSilo
       end
 
       def set_default(silo_name)
-        self[silo_name].tap do |silo|
-          raise NoSuchSiloError, "Silo '#{silo_name}' not found" unless silo
-
-          Config.user_data.set(:default_silo, value: silo.name)
-          Config.save_user_data
-        end
+        Config.user_data.set(:default_silo, value: silo.name)
+        Config.save_user_data
       end
 
       def check_prepared(type)

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -92,7 +92,7 @@ module FlightSilo
       end
 
       def set_default(silo_name)
-        Config.user_data.set(:default_silo, value: silo.name)
+        Config.user_data.set(:default_silo, value: silo_name)
         Config.save_user_data
       end
 
@@ -261,9 +261,11 @@ module FlightSilo
       if cloud_md["name"] != name || cloud_md["description"] != description
         if forced || Config.force_refresh
           md = YAML.load(File.read("#{Config.user_silos_path}/#{id}.yaml"))
-          md["name"] = cloud_md["name"]
-          Silo.set_default(cloud_md["name"]) if @name == Config.user_data.fetch(:default_silo)
+
           @name = cloud_md["name"]
+          Silo.set_default(cloud_md["name"]) if md["name"] == Config.user_data.fetch(:default_silo)
+          md["name"] = cloud_md["name"]
+
           md["description"] = cloud_md["description"]
           @description = cloud_md["description"]
           File.write("#{Config.user_silos_path}/#{id}.yaml", md.to_yaml)

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -240,6 +240,9 @@ module FlightSilo
     end
 
     def set_metadata(data)
+      if @name != data["name"] && !self.class.get_silo(name: data["name"], type: @type, creds: @creds)&.empty?
+        raise RemoteSiloExistsError, "A silo named '#{name}' already exists on remote provider '#{type.name}'"
+      end
       File.write('/tmp/#{silo.id}_cloud_metadata.yaml', data.to_yaml)
       push('/tmp/#{silo.id}_cloud_metadata.yaml', 'cloud_metadata.yaml')
       File.delete('/tmp/#{silo.id}_cloud_metadata.yaml')


### PR DESCRIPTION
This PR introduces the `repo edit` command. This command allows users to edit the metadata of silos. Currently, these details are the silo name and description. The command updates both upstream and local metadata. If the user renames the silo which has been set as the default silo, the value of `Silo#default` will be updated to reflect this change (thus keeping the default silo the same).

This creates a potential mismatch of information between local data and upstream data if a user has edited the details of a silo on one machine but not another. To remedy this, Silos now have a means to refresh their metadata to match the upstream values, using the `repo refresh` command. Each time a silo is directly accessed, its local metadata is checked against the upstream metadata to determine if there is a mismatch. If there is, the action is aborted and the user is prompted to run `repo refresh`. If the new config option `force_refresh` is used, then the user will not see this prompt and silos will be refreshed automatically when used.

This PR also removes the `Silo#fetch` function because it is not used.