### PR TITLE
Fix uncaught file permission error and AWS commands too quiet

### DIFF
--- a/etc/types/aws/actions/pull.sh
+++ b/etc/types/aws/actions/pull.sh
@@ -4,4 +4,4 @@ test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
 test $SILO_RECURSIVE = "true" && recursive=--recursive || recursive=""
 object_uri="s3://$SILO_NAME/$SILO_SOURCE"
 destination=${SILO_DEST:=/dev/stdout}
-$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" "$destination" $sign_request $recursive --quiet
+$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" "$destination" $sign_request $recursive --only-show-errors

--- a/etc/types/openstack/actions/pull.sh
+++ b/etc/types/openstack/actions/pull.sh
@@ -4,4 +4,4 @@ test $SILO_PUBLIC = "true" && sign_request=--no-sign-request || sign_request=""
 test $SILO_RECURSIVE = "true" && recursive=--recursive || recursive=""
 object_uri="s3://$SILO_NAME/$SILO_SOURCE"
 destination=${SILO_DEST:=/dev/stdout}
-$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" "$destination" $sign_request $recursive --quiet
+$SILO_TYPE_DIR/cli/bin/aws s3 cp "$object_uri" "$destination" $sign_request $recursive --only-show-errors

--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -60,6 +60,7 @@ module FlightSilo
         end
 
         software_dir = @options.dir || Config.user_software_dir
+        raise "User does not have permission to create files in the directory '#{software_dir}'" unless File.writable?(software_dir)
         extract_path = File.join(
           software_dir,
           name,

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -210,6 +210,8 @@ module FlightSilo
 
     def pull(source, dest, recursive: false)
       self.class.check_prepared(@type)
+      parent = File.expand_path("..", dest)
+      raise "User does not have permission to create files in the directory '#{parent}'" unless File.writable?(parent)
       env = {
         'SILO_NAME' => @id,
         'SILO_SOURCE' => source,


### PR DESCRIPTION
This small PR fixes a couple of long-standing issues.

- Attempting to `file pull` or `software pull` to a directory that is not writeable will now raise an error before downloading the content.
- The `s3 cp` command used in the AWS and Openstack types will now show STDERR instead of suppressing it.