### PR TITLE
Highlight missing repos in `repo list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Flight Silo has some optional configuration settings available. A
 Use `type avail` to list available provider types, and use `type prepare` to 
 prepare any required types.
 
-`repo avail` will list accessible silos.
+`repo list` will list accessible silos. Silos which exist locally but not upstream
+are coloured yellow in this list.
 
 `repo add` will add an existing silo to your system.
 

--- a/etc/types/aws/actions/create.sh
+++ b/etc/types/aws/actions/create.sh
@@ -5,6 +5,6 @@ $SILO_TYPE_DIR/cli/bin/aws s3 mb s3://$bucket
 $SILO_TYPE_DIR/cli/bin/aws s3api put-object --bucket $bucket --key files/
 $SILO_TYPE_DIR/cli/bin/aws s3api put-object --bucket $bucket --key projects/
 $SILO_TYPE_DIR/cli/bin/aws s3api put-object --bucket $bucket --key software/
-printf -- "---\nname: $SILO_NAME\ndescription:\nis_public: false\n" > "/tmp/${SILO_ID}_cloud_md.yaml"
+printf -- "---\nname: \"$SILO_NAME\"\ndescription:\nis_public: false\n" > "/tmp/${SILO_ID}_cloud_md.yaml"
 $SILO_TYPE_DIR/cli/bin/aws s3api put-object --bucket $bucket --key cloud_metadata.yaml --body "/tmp/${SILO_ID}_cloud_md.yaml"
 rm -f "/tmp/${SILO_ID}_cloud_md.yaml"

--- a/lib/silo/cli.rb
+++ b/lib/silo/cli.rb
@@ -114,7 +114,7 @@ module FlightSilo
 
     command 'repo list' do |c|
       cli_syntax(c)
-      c.description = "List available existing silos"
+      c.description = "List available existing silos. Silos not found upstream are coloured yellow in this list."
       c.action Commands, :repo_list
     end
 

--- a/lib/silo/commands/repo_list.rb
+++ b/lib/silo/commands/repo_list.rb
@@ -38,7 +38,7 @@ module FlightSilo
           table = Table.new
           table.headers 'Name', 'Description', 'Platform', 'Public?', 'ID'
           Silo.all.each do |s|
-            table.row Paint[s.name, :cyan],
+            table.row (s.deleted ? Paint[s.name, :yellow] : Paint[s.name, :cyan]),
                       Paint[s.description, :green],
                       Paint[s.type.name, :cyan],
                       s.is_public,

--- a/lib/silo/commands/repo_list.rb
+++ b/lib/silo/commands/repo_list.rb
@@ -38,7 +38,7 @@ module FlightSilo
           table = Table.new
           table.headers 'Name', 'Description', 'Platform', 'Public?', 'ID'
           Silo.all.each do |s|
-            table.row (s.deleted ? Paint[s.name, :yellow] : Paint[s.name, :cyan]),
+            table.row (s.deleted? ? Paint[s.name, :yellow] : Paint[s.name, :cyan]),
                       Paint[s.description, :green],
                       Paint[s.type.name, :cyan],
                       s.is_public,

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -290,7 +290,11 @@ module FlightSilo
       end
     end
 
-    attr_reader :name, :type, :global, :description, :is_public, :creds, :id, :deleted
+    def deleted?
+      @deleted
+    end
+
+    attr_reader :name, :type, :global, :description, :is_public, :creds, :id
 
     def initialize(global: false, md: {})
       @name = md.delete("name")

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -254,7 +254,7 @@ module FlightSilo
 
     def refresh(forced: false)
       self.class.check_prepared(@type)
-      if self.class.get_silo(name: @name, type: @type, creds: @creds)&.empty?
+      unless dir_exists?("")
         md = YAML.load(File.read("#{Config.user_silos_path}/#{id}.yaml"))
         md["deleted"] = true
         @deleted = true

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -259,7 +259,7 @@ module FlightSilo
         md["deleted"] = true
         @deleted = true
         File.write("#{Config.user_silos_path}/#{id}.yaml", md.to_yaml)
-        raise NoSuchSiloError, "Silo '#{name}' (#{id}) does not exist on the upstream repository. Local data is incorrect, or it was deleted from another machine."
+        raise NoSuchSiloError, "Silo '#{name}' (#{id}) does not exist upstream. Local data is incorrect, or it was deleted from another machine."
       end
       env = {
         'SILO_NAME' => id,

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -254,11 +254,12 @@ module FlightSilo
 
     def refresh(forced: false)
       self.class.check_prepared(@type)
-      if self.class.get_silo(name: data["name"], type: @type, creds: @creds)&.empty?
+      if self.class.get_silo(name: @name, type: @type, creds: @creds)&.empty?
         md = YAML.load(File.read("#{Config.user_silos_path}/#{id}.yaml"))
         md["deleted"] = true
         @deleted = true
         File.write("#{Config.user_silos_path}/#{id}.yaml", md.to_yaml)
+        raise NoSuchSiloError, "Silo '#{name}' (#{id}) does not exist on the upstream repository. Local data is incorrect, or it was deleted from another machine."
       end
       env = {
         'SILO_NAME' => id,

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -254,6 +254,12 @@ module FlightSilo
 
     def refresh(forced: false)
       self.class.check_prepared(@type)
+      if self.class.get_silo(name: data["name"], type: @type, creds: @creds)&.empty?
+        md = YAML.load(File.read("#{Config.user_silos_path}/#{id}.yaml"))
+        md["deleted"] = true
+        @deleted = true
+        File.write("#{Config.user_silos_path}/#{id}.yaml", md.to_yaml)
+      end
       env = {
         'SILO_NAME' => id,
         'SILO_SOURCE' => 'cloud_metadata.yaml',

--- a/lib/silo/silo.rb
+++ b/lib/silo/silo.rb
@@ -283,7 +283,7 @@ module FlightSilo
       end
     end
 
-    attr_reader :name, :type, :global, :description, :is_public, :creds, :id
+    attr_reader :name, :type, :global, :description, :is_public, :creds, :id, :deleted
 
     def initialize(global: false, md: {})
       @name = md.delete("name")
@@ -291,6 +291,7 @@ module FlightSilo
       @description = md.delete("description")
       @is_public = md.delete("is_public")
       @id = md.delete("id")
+      @deleted = md.delete("deleted")
 
       @creds = md # Credentials are all unused metadata values
     end


### PR DESCRIPTION
This PR aims to fix some bad errors which could occur after using `repo delete` on a silo which exists locally on another machine. Every call of `Silo#refresh` (i.e. before every standard silo command) it will be checked whether a silo still exists. If it does not, the user is informed with an appropriate error. Silos which have been determined to be deleted are flagged locally as such and will be highlighted yellow when using the `repo list` command.

This PR also adds a minor change to enforce quotes around names in a silo's cloud metadata. Previously, YAML would try its best to interpret them as anything other than a string, which made silos with certain names (e.g. integer names) completely inaccessible once created.