### PR TITLE
Fix `repo remove` failing on deleted silos

### DIFF
--- a/lib/silo/commands/file_pull.rb
+++ b/lib/silo/commands/file_pull.rb
@@ -47,7 +47,7 @@ module FlightSilo
           source = args[0]
         end
 
-        dest = args[1] || Dir.pwd
+        dest = args[1] || Dir.pwd + '/'
 
         keep_parent = source[-1] == '/'
 

--- a/lib/silo/commands/repo_remove.rb
+++ b/lib/silo/commands/repo_remove.rb
@@ -38,7 +38,7 @@ module FlightSilo
   module Commands
     class RepoRemove < Command
       def run
-        raise "Silo '#{@args[0]}' not found" unless (silo = Silo[@args[0]])
+        raise "Silo '#{@args[0]}' not found" unless (silo = Silo[@args[0], refresh: false])
         raise 'Cannot remove public silos' if silo.is_public
 
         silo.remove


### PR DESCRIPTION
This small PR fixes a bug that prevents `repo remove` working on silos which were deleted upstream. The `repo remove` command will no longer force the silo to be refreshed before running.