### PR TITLE
Fix the Broken Migration Switch Function

### DIFF
--- a/lib/silo/migration.rb
+++ b/lib/silo/migration.rb
@@ -112,7 +112,7 @@ module FlightSilo
       raise "Archive \'#{archive_id}\' has already been enabled!" if archive_id == @enabled_archive
 
       unless archive_id
-        archive_id = ''.tap do |v|
+        archive_id = (+'').tap do |v|
           8.times { v << rand(97..121).chr }
         end
         @archives << MigrationArchive.new(archive_id)

--- a/lib/silo/migration.rb
+++ b/lib/silo/migration.rb
@@ -112,9 +112,7 @@ module FlightSilo
       raise "Archive \'#{archive_id}\' has already been enabled!" if archive_id == @enabled_archive
 
       unless archive_id
-        archive_id = (+'').tap do |v|
-          8.times { v << rand(97..121).chr }
-        end
+        archive_id = 8.times.map { rand(97..121).chr }.join
         @archives << MigrationArchive.new(archive_id)
       end
       raise 'Archive does not exist' unless get_archive(archive_id)


### PR DESCRIPTION
This is a small PR to fix the issue that the migration archive ID cannot be generated due to the frozen string.