### PR TITLE
Clear Residual Migration Code in Software Push Command

### DIFF
--- a/lib/silo/commands/software_pull.rb
+++ b/lib/silo/commands/software_pull.rb
@@ -66,11 +66,13 @@ module FlightSilo
 
           cur = File.expand_path('..', cur)
         end
+
         extract_dir = File.join(
           software_dir,
           name,
           version
         )
+
         absolute = !File.expand_path(software_dir).start_with?(Dir.home)
         migration_dir = absolute ? File.expand_path(extract_dir) : File.expand_path(extract_dir).sub(Dir.home, '')
 
@@ -99,7 +101,7 @@ module FlightSilo
 
         extract_tar_gz(tmp_path, extract_dir, mkdir_p: true)
 
-        puts "Extracted software '#{name}' version '#{version}' to '#{Config.user_software_dir}'..."
+        puts "Extracted software '#{name}' version '#{version}' to '#{software_dir}'..."
 
         if Migration.enabled
           puts 'Updating local migration archive...'

--- a/lib/silo/commands/software_push.rb
+++ b/lib/silo/commands/software_push.rb
@@ -69,17 +69,9 @@ module FlightSilo
         upstream_name = "#{name}~#{version}.software"
 
         if !@options.force && silo.find_software(name, version)
-
-          error_msg = "Already exists: '#{name}' version '#{version}' on silo '#{silo_name}' (use --force to bypass)."
-          unless SoftwareMigration.get_archive.any? { |item| item['name'] == name && item['version'] == version }
-            migration_item = MigrationItem.new('software', name, version, software_path, true, silo.id)
-            repo_items = SoftwareMigration.add(migration_item)
-            error_msg += 'The migration archive has been updated.'
-          end
-
           raise <<~ERROR.chomp
 
-            #{error_msg}
+            Already exists: '#{name}' version '#{version}' on silo '#{silo_name}' (use --force to bypass).
           ERROR
         end
 


### PR DESCRIPTION
# Overview

This small PR aims to clear the residual migration-related code in `software_push.rb` since the migration is no longer monitoring the software push operation.