### PR TITLE
Migration Compatibility for Legacy Silos

### DIFF
--- a/lib/silo/commands/repo_add.rb
+++ b/lib/silo/commands/repo_add.rb
@@ -62,7 +62,12 @@ module FlightSilo
         Silo.reload_all
         silo = Silo[silo_name]
         dest = File.join(Config.migration_dir, 'temp', "migration_#{silo.id}.yml")
-        silo.pull('migration.yml', dest)
+        if silo.file_exists?('migration.yml')
+          silo.pull('migration.yml', dest)
+        else
+          RepoMigration.new(dest, silo.id)
+          silo.push(dest, 'migration.yml')
+        end
         Migration.add_repo(RepoMigration.new(dest, silo.id))
         File.delete(dest)
 


### PR DESCRIPTION
# Overview

This small PR aims to make the newly introduced migration features compatible with the silos created in the past. An empty migration data will be initialized when the user adds a legacy silo.